### PR TITLE
Fix broken functionality via URI changes and submodule updates

### DIFF
--- a/phyx/from_papers/Brochu 2003/paper.json
+++ b/phyx/from_papers/Brochu 2003/paper.json
@@ -1120,5 +1120,5 @@
         }
     ],
     "title": "Phylogenetic Approaches Toward Crocodylian History",
-    "@context": "https://www.ggvaidya.com/curation-tool/json/phyx.json"
+    "@context": "http://phyloref.org/curation-tool/json/phyx.json"
 }

--- a/phyx/from_papers/Wojciechowski, 2013/paper.json
+++ b/phyx/from_papers/Wojciechowski, 2013/paper.json
@@ -1,5 +1,5 @@
 {
-    "@context": "http://ggvaidya.com/curation-tool/json/phyx.json",
+    "@context": "http://phyloref.org/curation-tool/json/phyx.json",
     "doi": "10.1016/j.sajb.2013.06.017",
     "url": "https://www.sciencedirect.com/science/article/pii/S0254629913002962",
     "citation": "Wojciechowski (Nov 2013) South African Journal of Botany 89:85-93",


### PR DESCRIPTION
Two things broke the functioning of the Clade Ontology:
1. We still had references to the development version of the Clade Ontology, which this PR replaces with the production version.
2. We used an earlier version of the Curation Tool as a submodule, which meant that we weren't using the correct version IRI and we asserted that all phyloreferences were subclasses of `phyloref:Phyloreference`, which broke JPhyloRef. This has now been fixed in the Curation Tool (phyloref/curation-tool#135) and that version is imported here.