### PR TITLE
Adds a phyx2ontology.js script for building a synthesized Clade Ontology

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@phyloref/phyx/-/phyx-0.1.2.tgz",
       "integrity": "sha512-/tJi1VzWoWGnm4Sxqc9YnEljLdI77u+xhAc4em/ciVs/ihWAK/h9C7ZcsN2syUMwJ9TDHVol5BB3J+92XaTEUA==",
-      "dev": true,
       "requires": {
         "extend": "^3.0.2",
         "moment": "^2.23.0",
@@ -38,8 +37,7 @@
         "moment": {
           "version": "2.24.0",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-          "dev": true
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         }
       }
     },
@@ -76,8 +74,7 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "dev": true
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -137,6 +134,11 @@
       "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
@@ -189,6 +191,21 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -226,7 +243,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -243,6 +259,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -288,6 +309,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -489,6 +518,14 @@
       "dev": true,
       "requires": {
         "ramda": "^0.26.1"
+      },
+      "dependencies": {
+        "ramda": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+          "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+          "dev": true
+        }
       }
     },
     "eslint-restricted-globals": {
@@ -566,11 +603,24 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "external-editor": {
       "version": "3.0.3",
@@ -620,12 +670,11 @@
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat-cache": {
@@ -663,11 +712,24 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -819,6 +881,11 @@
         }
       }
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -840,8 +907,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-promise": {
       "version": "2.1.0",
@@ -857,6 +923,11 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -876,8 +947,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -907,6 +977,14 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -930,12 +1008,11 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
     },
@@ -945,11 +1022,28 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^1.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1015,14 +1109,12 @@
     "newick-js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/newick-js/-/newick-js-1.1.0.tgz",
-      "integrity": "sha512-lIdQGwqVD3x6kPK/kANgIM4oMZd/OmnxbaJRp0eycZoSNcAjyMshGyW5RVKsmVhkd69RNfwDqj+0/nwf7m3k6A==",
-      "dev": true
+      "integrity": "sha512-lIdQGwqVD3x6kPK/kANgIM4oMZd/OmnxbaJRp0eycZoSNcAjyMshGyW5RVKsmVhkd69RNfwDqj+0/nwf7m3k6A=="
     },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -1035,6 +1127,19 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-keys": {
       "version": "1.1.0",
@@ -1070,7 +1175,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1098,35 +1202,57 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+    },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "parent-module": {
       "version": "1.0.0",
@@ -1149,8 +1275,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1167,8 +1292,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1204,6 +1328,51 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "prelude-ls": {
@@ -1218,16 +1387,19 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
-    "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "dev": true
     },
     "read-pkg": {
@@ -1249,6 +1421,51 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "regexpp": {
@@ -1256,6 +1473,16 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
     "resolve": {
       "version": "1.10.0",
@@ -1334,14 +1561,17 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -1349,14 +1579,12 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -1411,7 +1639,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -1421,7 +1648,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -1431,6 +1657,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1552,10 +1783,14 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -1563,11 +1798,52 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -1576,6 +1852,39 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+    },
+    "yargs": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,8 +1019,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/phyloref/clade-ontology#readme",
   "dependencies": {
     "@phyloref/phyx": "^0.1.2",
+    "lodash": "^4.17.11",
     "yargs": "^12.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "url": "https://github.com/phyloref/clade-ontology/issues"
   },
   "homepage": "https://github.com/phyloref/clade-ontology#readme",
-  "devDependencies": {
+  "dependencies": {
     "@phyloref/phyx": "^0.1.2",
+    "yargs": "^12.0.5"
+  },
+  "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
     "eslint": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "directories": {},
   "scripts": {
-    "lint": "eslint \"test/**\" --ext .js",
+    "lint": "eslint \"test/**\" \"phyx2ontology/**\" --ext .js",
     "pretest": "npm run lint",
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "lint": "eslint \"test/**\" \"phyx2ontology/**\" --ext .js",
     "pretest": "npm run lint",
-    "test": "mocha"
+    "test": "mocha",
+    "build-ontology": "node phyx2ontology/phyx2ontology.js phyx/ > CLADO.json"
   },
   "repository": {
     "type": "git",

--- a/phyx2ontology/model2.js
+++ b/phyx2ontology/model2.js
@@ -1,0 +1,356 @@
+/*
+ * This temporary file is used to store methods that are used to convert
+ * the OWL restriction expressions from the model 1.0 implementation in
+ * phyx.js to the model 2.0 implemention currently produced by phyx2ontology.js.
+ * They will eventually be moved to phyx.js in https://github.com/phyloref/phyx.js/issues/4
+ */
+
+// We need to access some features from phyx.js.
+const phyx = require('@phyloref/phyx');
+
+// We need a few methods from lodash.
+const { has } = require('lodash');
+
+/*
+  * convertTUtoRestriction(tunit)
+  *  - tunit: A taxonomic unit (or a specifier containing at least one taxonomic unit)
+  *
+  * Converts a taxonomic unit to a list of OWL restrictions, in the form of:
+  *  tc:hasName some (ICZN_Name and dwc:scientificName value "scientific name")
+  * or:
+  *  tc:circumscribedBy some (dwc:organismID value "occurrence ID")
+  *
+ * This method will be moved back into phyx.js as part of https://github.com/phyloref/phyx.js/issues/4
+  */
+function convertTUtoRestriction(tunit) {
+  // If we're called with a specifier, use the first TU in that specifier (for now).
+  if (has(tunit, 'referencesTaxonomicUnits')) {
+    return convertTUtoRestriction(tunit.referencesTaxonomicUnits[0] || {});
+  }
+
+  // Build up a series of taxonomic units from scientific names and specimens.
+  const results = [];
+  if (has(tunit, 'scientificNames')) {
+    tunit.scientificNames.forEach((sciname) => {
+      const wrappedSciname = new phyx.ScientificNameWrapper(sciname);
+
+      results.push({
+        '@type': 'owl:Restriction',
+        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+        someValuesFrom: {
+          '@type': 'owl:Class',
+          intersectionOf: [
+            {
+              // TODO: replace with a check once we close https://github.com/phyloref/phyx.js/issues/5.
+              // For now, we pretend that all names are ICZN names.
+              '@id': 'obo:NOMEN_0000107',
+            },
+            {
+              '@type': 'owl:Restriction',
+              onProperty: 'dwc:scientificName',
+              // TODO: We really want the "canonical name" here: binomial or
+              // trinomial, but without any additional authority information.
+              // See https://github.com/phyloref/phyx.js/issues/8
+              hasValue: wrappedSciname.binomialName,
+            },
+          ],
+        },
+      });
+    });
+  } else if (has(tunit, 'includesSpecimens')) {
+    // This is a quick-and-dirty implementation. Discussion about it should be
+    // carried out in https://github.com/phyloref/clade-ontology/issues/61
+    tunit.includesSpecimens.forEach((specimen) => {
+      const wrappedSpecimen = new phyx.SpecimenWrapper(specimen);
+
+      results.push({
+        '@type': 'owl:Restriction',
+        onProperty: 'dwc:organismID',
+        hasValue: wrappedSpecimen.occurrenceID,
+      });
+    });
+  } else {
+    // Ignore it for now (but warn the user).
+    process.stderr.write(`WARNING: taxonomic unit could not be converted into restriction: ${JSON.stringify(tunit)}\n`);
+    results.push({});
+  }
+
+  return results;
+}
+
+let additionalClassCount = 0;
+const additionalClassesByLabel = {};
+function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, equivClassFunc) {
+  // This function creates an additional class for the set of internal and external
+  // specifiers provided for the equivalentClass expression provided. If one already
+  // exists for this set of internal and external specifiers, we just return that
+  // instead of creating a new one.
+  //
+  // For some reason this acts strange if equivalentClass is a string, so instead
+  // I've made it into a function here.
+
+  if (internalSpecifiers.length === 0) throw new Error('Cannot create additional class without any internal specifiers');
+  if (internalSpecifiers.length === 1 && externalSpecifiers.length === 0) throw new Error('Cannot create additional class with a single internal specifiers and no external specifiers');
+
+  // TODO We need to replace this with an actual object-based comparison,
+  // rather than trusting the labels to tell us everything.
+  const externalSpecifierLabel = ` ~ ${externalSpecifiers
+    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
+    .sort()
+    .join(' V ')}`;
+
+  // Add the internal specifiers to this.
+  const additionalClassLabel = `(${internalSpecifiers
+    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
+    .sort()
+    .join(' & ')
+  }${externalSpecifiers.length > 0 ? externalSpecifierLabel : ''
+  })`;
+
+  process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
+
+  if (has(additionalClassesByLabel, additionalClassLabel)) {
+    process.stderr.write(`Found additional class with id: ${additionalClassesByLabel[additionalClassLabel]['@id']}\n`);
+    return { '@id': additionalClassesByLabel[additionalClassLabel]['@id'] };
+  }
+
+  additionalClassCount += 1;
+  const additionalClass = {};
+  additionalClass['@id'] = `${jsonld['@id']}_additional${additionalClassCount}`;
+  process.stderr.write(`Creating new additionalClass with id: ${additionalClass['@id']}`);
+
+  additionalClass['@type'] = 'owl:Class';
+  additionalClass.subClassOf = (
+    externalSpecifiers.length > 0 ? 'phyloref:PhyloreferenceUsingMinimumClade' : 'phyloref:PhyloreferenceUsingMaximumClade'
+  );
+  additionalClass.equivalentClass = equivClassFunc();
+  additionalClass.label = additionalClassLabel;
+  jsonld.hasAdditionalClass.push(additionalClass);
+
+  additionalClassesByLabel[additionalClassLabel] = additionalClass;
+
+  return { '@id': additionalClass['@id'] };
+}
+
+function getIncludesRestrictionForTU(tu) {
+  return {
+    '@type': 'owl:Restriction',
+    onProperty: 'phyloref:includes_TU',
+    someValuesFrom: convertTUtoRestriction(tu)[0],
+  };
+}
+
+
+function getMRCA2Expression(tu1, tu2) {
+  return {
+    '@type': 'owl:Restriction',
+    onProperty: 'obo:CDAO_0000149', // cdao:has_Child
+    someValuesFrom: {
+      '@type': 'owl:Class',
+      intersectionOf: [
+        {
+          '@type': 'owl:Restriction',
+          onProperty: 'phyloref:excludes_TU',
+          someValuesFrom: convertTUtoRestriction(tu1)[0],
+        },
+        getIncludesRestrictionForTU(tu2),
+      ],
+    },
+  };
+}
+
+
+function createClassExpressionsForInternals(jsonld, remainingInternals, selected) {
+  // Create a class expression for a phyloref made up entirely of internal specifiers.
+  //  - additionalClasses: used to store additional classes as needed.
+  //  - remainingInternals: taxonomic units remaining to be included.
+  //  - selected: taxonomic units that have been selected already.
+
+  // This algorithm works like this:
+  //  - 1. We start with everything remaining and nothing selected.
+  //  - 2. We recurse into this method, moving everything in remaining into selected one by one.
+  //    - Think of it as a tree: the root node selects each internal once, and then each child node
+  //      selects one additional item from remaining, and so on.
+  process.stderr.write(`@id [${jsonld['@id']}] Remaining internals: ${remainingInternals.length}, selected: ${selected.length}\n`);
+
+  // Quick special case: if we have two 'remainingInternals' and zero selecteds,
+  // we can just return the MRCA for two internal specifiers.
+  if (selected.length === 0) {
+    if (remainingInternals.length === 2) {
+      return [getMRCA2Expression(remainingInternals[0], remainingInternals[1])];
+    } if (remainingInternals.length === 1) {
+      throw new Error('Cannot determine class expression for a single specifier');
+    } else if (remainingInternals.length === 0) {
+      throw new Error('Cannot determine class expression for zero specifiers');
+    }
+  }
+
+  // Step 1. If we've already selected something, create an expression for it.
+  const classExprs = [];
+  if (selected.length > 0) {
+    let remainingInternalsExpr = [];
+    if (remainingInternals.length === 1) {
+      remainingInternalsExpr = getIncludesRestrictionForTU(remainingInternals[0]);
+    } else if (remainingInternals.length === 2) {
+      remainingInternalsExpr = getMRCA2Expression(remainingInternals[0], remainingInternals[1]);
+    } else {
+      remainingInternalsExpr = createAdditionalClass(
+        jsonld,
+        remainingInternals,
+        [],
+        () => createClassExpressionsForInternals(jsonld, remainingInternals, [])
+      );
+    }
+
+    let selectedExpr = [];
+    if (selected.length === 1) {
+      selectedExpr = getIncludesRestrictionForTU(selected[0]);
+    } else if (selected.length === 2) {
+      selectedExpr = getMRCA2Expression(selected[0], selected[1]);
+    } else {
+      selectedExpr = createAdditionalClass(
+        jsonld,
+        selected,
+        [],
+        () => createClassExpressionsForInternals(jsonld, selected, [])
+      );
+    }
+
+    classExprs.push({
+      '@type': 'owl:Restriction',
+      onProperty: 'obo:CDAO_0000149', // cdao:has_Child
+      someValuesFrom: {
+        '@type': 'owl:Class',
+        intersectionOf: [{
+          '@type': 'owl:Restriction',
+          onProperty: 'phyloref:excludes_lineage_to',
+          someValuesFrom: remainingInternalsExpr,
+        }, selectedExpr],
+      },
+    });
+  }
+
+  // Step 2. Now select everything from remaining once, and start recursing through
+  // every possibility.
+  // Note that we only process cases where there are more remainingInternals than
+  // selected internals -- when there are fewer, we'll just end up with the inverses
+  // of the previous comparisons, which we'll already have covered.
+  // TODO: the other way around that would be to wrap *everything* into additional
+  // classes, which might be a useful thing to do anyway.
+  if (remainingInternals.length > 1 && selected.length <= remainingInternals.length) {
+    remainingInternals.map((newlySelected) => {
+      process.stderr.write(`Selecting new object, remaining now at: ${remainingInternals.filter(i => i !== newlySelected).length}, selected: ${selected.concat([newlySelected]).length}\n`);
+      return createClassExpressionsForInternals(
+        jsonld,
+        // The new remaining is the old remaining minus the selected TU.
+        remainingInternals.filter(i => i !== newlySelected),
+        // The new selected is the old selected plus the selected TU.
+        selected.concat([newlySelected])
+      );
+    })
+      .reduce((acc, val) => acc.concat(val), [])
+      .forEach(expr => classExprs.push(expr));
+  }
+
+  return classExprs;
+}
+
+function getExclusionsForExprAndTU(includedExpr, tu) {
+  if (!includedExpr) throw new Error('Exclusions require an included expression');
+
+  const exprs = [{
+    '@type': 'owl:Class',
+    intersectionOf: [
+      includedExpr,
+      {
+        '@type': 'owl:Restriction',
+        onProperty: 'phyloref:excludes_TU',
+        someValuesFrom: convertTUtoRestriction(tu)[0],
+      },
+    ],
+  }];
+
+  if (!Array.isArray(includedExpr) && has(includedExpr, 'onProperty') && includedExpr.onProperty === 'phyloref:includes_TU') {
+    // In this specific set of circumstances, we do NOT need to add the has_Ancestor check.
+  } else {
+    // Add the has_Ancestor check!
+    exprs.push({
+      '@type': 'owl:Class',
+      intersectionOf: [
+        includedExpr,
+        {
+          '@type': 'owl:Restriction',
+          onProperty: 'obo:CDAO_0000144', // has_Ancestor
+          someValuesFrom: {
+            '@type': 'owl:Restriction',
+            onProperty: 'phyloref:excludes_TU',
+            someValuesFrom: convertTUtoRestriction(tu)[0],
+          },
+        },
+      ],
+    });
+  }
+
+  return exprs;
+}
+
+function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingExternals, selected) {
+  // When creating a class expression with external specifiers, we can treat the
+  // internal expression as evaluating to a particular set of nodes. Each external
+  // specifier can have one of two relationships with the internal expression node:
+  //  - It could directly excludes_TU the external specifier, or
+  //  - It could have an ancestor that excludes_TU the external specifier.
+  // For the single case, this is straightforward. But when there are multiple
+  // external specifiers, we must use the same recursive algorithm we use to
+  // ensure that we try them out in every possible combination.
+  process.stderr.write(`@id [${jsonld['@id']}] Remaining externals: ${remainingExternals.length}, selected: ${selected.length}\n`);
+
+  // Step 1. If we only have one external remaining, we can provide our two-case example
+  // to detect it.
+  const classExprs = [];
+  if (remainingExternals.length === 0) {
+    throw new Error('Cannot create class expression when no externals remain');
+  } else if (remainingExternals.length === 1) {
+    const remainingExternalsExprs = getExclusionsForExprAndTU(
+      accumulatedExpr,
+      remainingExternals[0],
+      selected.length > 0
+    );
+    remainingExternalsExprs.forEach(expr => classExprs.push(expr));
+  } else { // if(remainingExternals.length > 1)
+    // Recurse into remaining externals. Every time we select a single entry,
+    // we create a class expression for that.
+    remainingExternals.map((newlySelected) => {
+      process.stderr.write(`Selecting new object, remaining now at: ${remainingExternals.filter(i => i !== newlySelected).length}, selected: ${selected.concat([newlySelected]).length}\n`);
+
+      const newlyAccumulatedExpr = createAdditionalClass(
+        jsonld,
+        jsonld.internalSpecifiers,
+        selected.concat([newlySelected]),
+        () => getExclusionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
+      );
+
+      return createClassExpressionsForExternals(
+        jsonld,
+        newlyAccumulatedExpr,
+        // The new remaining is the old remaining minus the selected TU.
+        remainingExternals.filter(i => i !== newlySelected),
+        // The new selected is the old selected plus the selected TU.
+        selected.concat([newlySelected])
+      );
+    })
+      .reduce((acc, val) => acc.concat(val), [])
+      .forEach(expr => classExprs.push(expr));
+  }
+
+  // console.dir(classExprs, { depth: null })
+
+  return classExprs;
+}
+
+module.exports = {
+  convertTUtoRestriction,
+  getIncludesRestrictionForTU,
+  createClassExpressionsForInternals,
+  createClassExpressionsForExternals,
+};

--- a/phyx2ontology/model2.js
+++ b/phyx2ontology/model2.js
@@ -93,7 +93,7 @@ const additionalClassesByLabel = {};
  * - equivClassFunc: The equivalent class expression for this additional class as a function
  *   that returns the expression as a string.
  */
-function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, equivClassFunc) {
+function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, equivClass) {
   if (internalSpecifiers.length === 0) throw new Error('Cannot create additional class without any internal specifiers');
   if (internalSpecifiers.length === 1 && externalSpecifiers.length === 0) throw new Error('Cannot create additional class with a single internal specifiers and no external specifiers');
 
@@ -136,7 +136,7 @@ function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, e
   additionalClass.subClassOf = (
     externalSpecifiers.length > 0 ? 'phyloref:PhyloreferenceUsingMinimumClade' : 'phyloref:PhyloreferenceUsingMaximumClade'
   );
-  additionalClass.equivalentClass = equivClassFunc();
+  additionalClass.equivalentClass = equivClass;
   additionalClass.label = additionalClassLabel;
   jsonld.hasAdditionalClass.push(additionalClass);
 
@@ -231,7 +231,7 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
         jsonld,
         remainingInternals,
         [],
-        () => createClassExpressionsForInternals(jsonld, remainingInternals, [])
+        createClassExpressionsForInternals(jsonld, remainingInternals, [])
       );
     }
 
@@ -245,7 +245,7 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
         jsonld,
         selected,
         [],
-        () => createClassExpressionsForInternals(jsonld, selected, [])
+        createClassExpressionsForInternals(jsonld, selected, [])
       );
     }
 
@@ -390,7 +390,7 @@ function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingEx
         jsonld,
         jsonld.internalSpecifiers,
         selected.concat([newlySelected]),
-        () => getClassExpressionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
+        getClassExpressionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
       );
 
       // Call ourselves recursively to add the remaining externals.

--- a/phyx2ontology/model2.js
+++ b/phyx2ontology/model2.js
@@ -86,38 +86,46 @@ function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, e
   // exists for this set of internal and external specifiers, we just return that
   // instead of creating a new one.
   //
-  // For some reason this acts strange if equivalentClass is a string, so instead
-  // I've made it into a function here.
+  // TODO For some reason this acts strange if equivalentClass is a string, so instead
+  // I've made it into a function here. To be fixed.
 
   if (internalSpecifiers.length === 0) throw new Error('Cannot create additional class without any internal specifiers');
   if (internalSpecifiers.length === 1 && externalSpecifiers.length === 0) throw new Error('Cannot create additional class with a single internal specifiers and no external specifiers');
 
+  /* Come up with a label that represents this additional class. */
+
+  // Start with the internal specifiers, concatenated with '&'.
+  const internalSpecifierLabel = internalSpecifiers
+    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
+    .sort()
+    .join(' & ');
+  let additionalClassLabel = `(${internalSpecifierLabel}`;
+
+  if (externalSpecifiers.length === 0) {
+    additionalClassLabel += ')';
+  } else {
+    // Add the external specifiers, concatenated with 'V'.
+    const externalSpecifierLabel = externalSpecifiers
+      .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
+      .sort()
+      .join(' V ');
+    additionalClassLabel += ` ~ ${externalSpecifierLabel})`;
+  }
+
+  // process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
+
   // TODO We need to replace this with an actual object-based comparison,
   // rather than trusting the labels to tell us everything.
-  const externalSpecifierLabel = ` ~ ${externalSpecifiers
-    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
-    .sort()
-    .join(' V ')}`;
-
-  // Add the internal specifiers to this.
-  const additionalClassLabel = `(${internalSpecifiers
-    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
-    .sort()
-    .join(' & ')
-  }${externalSpecifiers.length > 0 ? externalSpecifierLabel : ''
-  })`;
-
-  process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
-
   if (has(additionalClassesByLabel, additionalClassLabel)) {
-    process.stderr.write(`Found additional class with id: ${additionalClassesByLabel[additionalClassLabel]['@id']}\n`);
+    // If we see the same label again, return the previously defined additional class.
     return { '@id': additionalClassesByLabel[additionalClassLabel]['@id'] };
   }
 
+  // Create a new additional class for this set of internal and external specifiers.
   additionalClassCount += 1;
   const additionalClass = {};
   additionalClass['@id'] = `${jsonld['@id']}_additional${additionalClassCount}`;
-  process.stderr.write(`Creating new additionalClass with id: ${additionalClass['@id']}`);
+  // process.stderr.write(`Creating new additionalClass with id: ${additionalClass['@id']}`);
 
   additionalClass['@type'] = 'owl:Class';
   additionalClass.subClassOf = (
@@ -132,6 +140,7 @@ function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, e
   return { '@id': additionalClass['@id'] };
 }
 
+/* Return an OWL restriction for inclusion of a single taxonomic unit. */
 function getIncludesRestrictionForTU(tu) {
   return {
     '@type': 'owl:Restriction',
@@ -140,8 +149,11 @@ function getIncludesRestrictionForTU(tu) {
   };
 }
 
-
-function getMRCA2Expression(tu1, tu2) {
+/*
+ * Return an OWL restriction for the most recent common ancestor (MRCA)
+ * of two taxonomic units.
+ */
+function getMRCARestrictionOfTwoTUs(tu1, tu2) {
   return {
     '@type': 'owl:Restriction',
     onProperty: 'obo:CDAO_0000149', // cdao:has_Child
@@ -159,25 +171,39 @@ function getMRCA2Expression(tu1, tu2) {
   };
 }
 
-
+/*
+ * Create an OWL restriction for a phyloreference made up entirely of internal
+ * specifiers.
+ *  - jsonld: the JSON-LD representation of this phyloreference in model 1.0.
+ *    We mainly use this to access the '@id' and internal and external specifiers.
+ *  - remainingInternals: all internal specifiers that have not yet been selected.
+ *  - selected: internal specifiers have been seen selected. This should initially
+ *    be [], and will be filled in when this method calls itself recursively.
+ *
+ * This method works like this:
+ *  1. We have several special cases: we fail if 0 or 1 specifiers are
+ *     provided, and we have a special representation for 2 specifiers.
+ *  2. Create an expression for the currently selected specifiers. This expression
+ *     is in the form:
+ *       has_Child some (excludes_lineage_to some [remaining specifiers] and [selected specifiers])
+ *     We generate the expressions for remaining specifiers and selected specifiers by calling
+ *     this method recursively.
+ *  3. Finally, we select another internal from the remainingInternals and generate an
+ *     expression for that selection by calling this method recursively. We stop doing
+ *     this once we've selected as many internals as are remaining, since at that point
+ *     we will have tried every possible combination of internals.
+ *
+ * This ensures that every sequence of internal specifiers are tested.
+ */
 function createClassExpressionsForInternals(jsonld, remainingInternals, selected) {
-  // Create a class expression for a phyloref made up entirely of internal specifiers.
-  //  - additionalClasses: used to store additional classes as needed.
-  //  - remainingInternals: taxonomic units remaining to be included.
-  //  - selected: taxonomic units that have been selected already.
-
-  // This algorithm works like this:
-  //  - 1. We start with everything remaining and nothing selected.
-  //  - 2. We recurse into this method, moving everything in remaining into selected one by one.
-  //    - Think of it as a tree: the root node selects each internal once, and then each child node
-  //      selects one additional item from remaining, and so on.
-  process.stderr.write(`@id [${jsonld['@id']}] Remaining internals: ${remainingInternals.length}, selected: ${selected.length}\n`);
+  // process.stderr.write(`@id [${jsonld['@id']}] Remaining internals:
+  // ${remainingInternals.length}, selected: ${selected.length}\n`);
 
   // Quick special case: if we have two 'remainingInternals' and zero selecteds,
   // we can just return the MRCA for two internal specifiers.
   if (selected.length === 0) {
     if (remainingInternals.length === 2) {
-      return [getMRCA2Expression(remainingInternals[0], remainingInternals[1])];
+      return [getMRCARestrictionOfTwoTUs(remainingInternals[0], remainingInternals[1])];
     } if (remainingInternals.length === 1) {
       throw new Error('Cannot determine class expression for a single specifier');
     } else if (remainingInternals.length === 0) {
@@ -192,7 +218,10 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
     if (remainingInternals.length === 1) {
       remainingInternalsExpr = getIncludesRestrictionForTU(remainingInternals[0]);
     } else if (remainingInternals.length === 2) {
-      remainingInternalsExpr = getMRCA2Expression(remainingInternals[0], remainingInternals[1]);
+      remainingInternalsExpr = getMRCARestrictionOfTwoTUs(
+        remainingInternals[0],
+        remainingInternals[1]
+      );
     } else {
       remainingInternalsExpr = createAdditionalClass(
         jsonld,
@@ -206,7 +235,7 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
     if (selected.length === 1) {
       selectedExpr = getIncludesRestrictionForTU(selected[0]);
     } else if (selected.length === 2) {
-      selectedExpr = getMRCA2Expression(selected[0], selected[1]);
+      selectedExpr = getMRCARestrictionOfTwoTUs(selected[0], selected[1]);
     } else {
       selectedExpr = createAdditionalClass(
         jsonld,
@@ -255,7 +284,19 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
   return classExprs;
 }
 
-function getExclusionsForExprAndTU(includedExpr, tu) {
+/*
+ * Given an expression that evaluates to an included node and a taxonomic unit,
+ * return an expression for including it and excluding the TU. Note that this
+ * always returns an array.
+ *
+ * When the included expression includes a single taxonomic unit (i.e. is in the
+ * form `includes_TU some [TU]`), then the simple form is adequate. However, when
+ * it's a more complex expression, it's possible that the excluded TU isn't just
+ * sister to this clade but outside of it entirely. In that case, we add another
+ * class expression:
+ *  [includesExpr] and (has_Ancestor some (excludes_TU some [TU]))
+ */
+function getClassExpressionsForExprAndTU(includedExpr, tu) {
   if (!includedExpr) throw new Error('Exclusions require an included expression');
 
   const exprs = [{
@@ -294,16 +335,35 @@ function getExclusionsForExprAndTU(includedExpr, tu) {
   return exprs;
 }
 
+/*
+ * Returns a list of class expressions for a phyloreference that has an expression
+ * for the MRCA of its internal specifiers, but also has one or more external specifiers.
+ *  - jsonld: The JSON-LD form of the Phyloreference from Model 1.0. Mainly used
+ *    for retrieving the '@id' and the specifiers.
+ *  - accumulatedExpr: Initially, an expression that evaluates to the MRCA of all
+ *    internal specifiers, calculated using createClassExpressionsForInternals().
+ *    When we call this method recusively, this expression will incorporate
+ *    representations of external references.
+ *  - remainingExternals: External specifiers that are yet to be incorporated into the
+ *    expressions we are building.
+ *  - selected: External specifiers that have already been selected.
+ *
+ * Our overall algorithm here is:
+ *  1. If we need to add a single remaining external to the accumulated expression,
+ *     we can do that by adding an `excludes_TU` to the expression (and possibly a
+ *     `has_Ancestor` check, see getClassExpressionsForExprAndTU()).
+ *  2. If we need to add more than one remaining external, we select each external
+ *     specifier one at a time. We add the selected specifier to the accumulated
+ *     expression using getClassExpressionsForExprAndTU(), and then call ourselves
+ *     recursively to add the remaining specifiers.
+ *
+ * The goal here is to create expressions for every possible sequence of external
+ * specifiers, so we can account for cases where some external specifiers are closer
+ * to the initial internal-specifier-only expression than others.
+ */
 function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingExternals, selected) {
-  // When creating a class expression with external specifiers, we can treat the
-  // internal expression as evaluating to a particular set of nodes. Each external
-  // specifier can have one of two relationships with the internal expression node:
-  //  - It could directly excludes_TU the external specifier, or
-  //  - It could have an ancestor that excludes_TU the external specifier.
-  // For the single case, this is straightforward. But when there are multiple
-  // external specifiers, we must use the same recursive algorithm we use to
-  // ensure that we try them out in every possible combination.
-  process.stderr.write(`@id [${jsonld['@id']}] Remaining externals: ${remainingExternals.length}, selected: ${selected.length}\n`);
+  // process.stderr.write(`@id [${jsonld['@id']}] Remaining externals:
+  // ${remainingExternals.length}, selected: ${selected.length}\n`);
 
   // Step 1. If we only have one external remaining, we can provide our two-case example
   // to detect it.
@@ -311,7 +371,7 @@ function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingEx
   if (remainingExternals.length === 0) {
     throw new Error('Cannot create class expression when no externals remain');
   } else if (remainingExternals.length === 1) {
-    const remainingExternalsExprs = getExclusionsForExprAndTU(
+    const remainingExternalsExprs = getClassExpressionsForExprAndTU(
       accumulatedExpr,
       remainingExternals[0],
       selected.length > 0
@@ -321,15 +381,20 @@ function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingEx
     // Recurse into remaining externals. Every time we select a single entry,
     // we create a class expression for that.
     remainingExternals.map((newlySelected) => {
-      process.stderr.write(`Selecting new object, remaining now at: ${remainingExternals.filter(i => i !== newlySelected).length}, selected: ${selected.concat([newlySelected]).length}\n`);
+      // process.stderr.write(`Selecting new object, remaining now at:
+      // ${remainingExternals.filter(i => i !== newlySelected).length},
+      // selected: ${selected.concat([newlySelected]).length}\n`);
 
+      // Create a new additional class for the accumulated expression plus the
+      // newly selected external specifier.
       const newlyAccumulatedExpr = createAdditionalClass(
         jsonld,
         jsonld.internalSpecifiers,
         selected.concat([newlySelected]),
-        () => getExclusionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
+        () => getClassExpressionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
       );
 
+      // Call ourselves recursively to add the remaining externals.
       return createClassExpressionsForExternals(
         jsonld,
         newlyAccumulatedExpr,
@@ -342,8 +407,6 @@ function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingEx
       .reduce((acc, val) => acc.concat(val), [])
       .forEach(expr => classExprs.push(expr));
   }
-
-  // console.dir(classExprs, { depth: null })
 
   return classExprs;
 }

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -199,6 +199,10 @@ for (let phyxFile of jsons) {
     delete jsonld['equivalentClass'];
     delete jsonld['hasAdditionalClass'];
 
+    // Finally, we still have the clade definition and other terms, but we call them by different names now.
+    jsonld['obo:IAO_0000115'] = jsonld['cladeDefinition'];
+    delete jsonld['cladeDefinition'];
+
     // Instead, from the specifiers, we construct different kinds of definitions in
     // This code will be moved into phyx.js once we're fully committed to Model 2.0,
     // but is here so we can see what the Clade Ontology would look like in Model 2.0.
@@ -235,6 +239,11 @@ for (let phyxFile of jsons) {
     entityIndex += 1;
     const phylogenyAsJSONLD = new phyx.PhylogenyWrapper(phylogeny).asJSONLD(getIdentifier(entityIndex));
 
+    // Change name for including Newick.
+    phylogenyAsJSONLD['phyloref:newick_expression'] = phylogenyAsJSONLD['newick'];
+    delete phylogenyAsJSONLD['newick'];
+
+    // Change how nodes are represented.
     (phylogenyAsJSONLD.nodes || []).forEach(node => {
       // Make sure this node has a '@type'.
       if(!hasOwnProperty(node, '@type')) node['@type'] = [];

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -365,7 +365,7 @@ function createClassExpressionsForInternals(jsonld, remainingInternals, selected
   return classExprs;
 }
 
-function getExclusionsForExprAndTU(includedExpr, tu, flagAddHasAncestorCheck) {
+function getExclusionsForExprAndTU(includedExpr, tu) {
   if(!includedExpr) throw new Error('Exclusions require an included expression');
 
   const exprs = [{
@@ -379,7 +379,11 @@ function getExclusionsForExprAndTU(includedExpr, tu, flagAddHasAncestorCheck) {
       },
     ],
   }];
-  if(flagAddHasAncestorCheck) {
+
+  if(!Array.isArray(includedExpr) && hasOwnProperty(includedExpr, 'onProperty') && includedExpr.onProperty === 'phyloref:includes_TU') {
+    // In this specific set of circumstances, we do NOT need to add the has_Ancestor check.
+  } else {
+    // Add the has_Ancestor check!
     exprs.push({
       '@type': 'owl:Class',
       'intersectionOf': [
@@ -396,6 +400,7 @@ function getExclusionsForExprAndTU(includedExpr, tu, flagAddHasAncestorCheck) {
       ],
     });
   }
+
   return exprs;
 }
 

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -60,18 +60,18 @@ function convertTUtoRestriction(tunit) {
         },
       });
     });
-  } else if (hasOwnProperty(tunit, 'includesSpecimens')) {
+  }
+
+  if (has(tunit, 'includesSpecimens')) {
+    // This is a quick-and-dirty implementation. Discussion about it should be
+    // carried out in https://github.com/phyloref/clade-ontology/issues/61
     tunit.includesSpecimens.forEach((specimen) => {
       const wrappedSpecimen = new phyx.SpecimenWrapper(specimen);
 
       results.push({
         '@type': 'owl:Restriction',
-        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#circumscribedBy',
-        someValuesFrom: {
-          '@type': 'owl:Restriction',
-          onProperty: 'dwc:organismID', // TODO Technically, this should be a token. Probably.
-          hasValue: wrappedSpecimen.occurrenceID,
-        },
+        onProperty: 'dwc:organismID',
+        hasValue: wrappedSpecimen.occurrenceID,
       });
     });
   } else {

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -1,0 +1,202 @@
+/*
+ * phyx2ontology.js: A tool for synthesizing all PHYX files into a single
+ * Clade Ontology in JSON-LD.
+ *
+ * Synopsis: phyx2ontology.js [-d root] > ontology.json
+ *
+ * Arguments:
+ *  - `-d`: Set the directory to look for PHYX files in.
+ */
+
+// Configuration options.
+const PHYX_CONTEXT_JSON = 'http://www.phyloref.org/curation-tool/json/phyx.json';
+const CLADE_ONTOLOGY_BASEURI = 'http://phyloref.org/clade-ontology/clado.owl';
+
+// Load necessary modules.
+const process = require('process');
+const fs = require('fs');
+const path = require('path');
+
+/*
+ * phyx.js uses some code (in particular through phylotree.js) that expects certain
+ * Javascript libraries to be loaded via the browser using <script>. To replicate
+ * this in Node, we load them and add them to the global object.
+ */
+
+// Load moment as a global variable so it can be accessed by phyx.js.
+global.moment = require('moment');
+
+// Load jQuery.extend as a global variable so it can be accessed by phyx.js.
+global.jQuery = {};
+global.jQuery.extend = require('extend');
+
+// Load d3 as a global variable so it can be accessed by both phylotree.js (which
+// needs to add additional objects to it) and phyx.js (which needs to call it).
+global.d3 = require('d3');
+
+// Define hasOwnProperty() so we can use it on all classes.
+function hasOwnProperty(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+// phylotree.js does not export functions itself, but adds them to global.d3.layout.
+// So we set up a global.d3.layout object for them to be added to, and then we include
+// phylotree.js ourselves.
+if (!hasOwnProperty(global.d3, 'layout')) {
+  global.d3.layout = {};
+}
+require('../curation-tool/lib/phylotree.js/phylotree.js');
+
+// Load phyx.js, our PHYX library.
+const phyx = require('../curation-tool/js/phyx');
+
+// Helper methods.
+
+/*
+ * Returns a list of PHYX files that we can test in the provided directory.
+ *
+ * We use a simple flatMap to search for these files. Since flatMap isn't in
+ * Node.js yet, I use a map to recursively find the files and then flatten it
+ * using reduce() and concat().
+ *
+ * This could be implemented asynchronously, but we need a list of files to
+ * test each one individually in Mocha, so we need a synchronous implementation
+ * to get that list before we start testing.
+ */
+function findPHYXFiles(dirPath) {
+    return fs.readdirSync(dirPath).map(function(filename) {
+        const filePath = path.join(dirPath, filename);
+
+        if(fs.lstatSync(filePath).isDirectory()) {
+            // Recurse into this directory.
+            return findPHYXFiles(filePath);
+        } else {
+            // Look for .json files (but not for '_as_owl.json' files, for historical reasons).
+            if(filePath.endsWith('.json') && !filePath.endsWith('_as_owl.json')) {
+                return [filePath];
+            } else {
+                return [];
+            }
+        }
+   }).reduce((x, y) => x.concat(y), []); // This flattens the list of results.
+}
+
+// Read command-line arguments.
+const argv = require('yargs')
+  .usage('Usage: $0 [-d root]')
+  .alias('d', 'dir')
+  .nargs('d', 1)
+  .describe('d', 'Directory to look for PHYX files in')
+  .help('h')
+  .alias('h', 'help')
+  .argv;
+
+// Make sure there are no unknown arguments.
+if (argv._.length > 0) {
+  throw new Error('Unknown arguments: ' + argv._);
+}
+
+// Determine the directory to process.
+const dir = argv.dir || process.cwd();
+// process.stderr.write(`Searching directory: ${dir}\n`);
+
+// Get list of PHYX files to process.
+const phyxFiles = findPHYXFiles(dir);
+// process.stderr.write(`PHYX files to combine: ${phyxFiles}`);
+
+// It would be pretty easy to convert each individual PHYX file into a JSON-LD file by
+// using the phyx2jsonld module. However, we would then have to identify every URI in
+// the file and rename all of them, which could be confusing.
+let entityIndex = 0;
+function getIdentifier(index) {
+  return `${CLADE_ONTOLOGY_BASEURI}#CLADO_${index.toString().padStart(8, '0')}`;
+}
+
+// Loop through our files and assemble a combined ontology.
+const jsons = phyxFiles
+  .map(filename => {
+    const content = fs.readFileSync(filename);
+
+    // Some of these PHYX files are encrypted! We need to ignore those.
+    if(content.slice(0, 9).equals(Buffer.from("\x00GITCRYPT"))) {
+      return [];
+    }
+
+    // Try to read this PHYX file as a JSON file.
+    let json;
+    try {
+      json = JSON.parse(content.toString('utf8'));
+    } catch(err) {
+      process.stderr.write(`WARNING: ${filename} could not be read as JSON, skipping.`);
+      return [];
+    }
+
+    // If not encrypted, we can treat this file as UTF-8 and read it as a string.
+    return [json];
+  })
+  // Flatten map to remove files that could not be read or parsed.
+  .reduce((a, b) => a.concat(b), []);
+
+/*
+ * We'd like our combine JSON-LD file to be in this format:
+ * [{
+ *    '@context': 'http://phyloref.org/curation-tool/json/phyx.json',
+ *    '@id': 'http://vocab.phyloref.org/clado/',
+ *    '@type': 'owl:Ontology'
+ *    [... ontology metadata ...]
+ * }, {
+ *    '@context': 'http://phyloref.org/curation-tool/json/phyx.json',
+ *    '@id': 'http://vocab.phyloref.org/clado/CLADO_PHYLOREF_1',
+ *    '@type': 'phyloref:Phyloreference',
+ *    'label': '...',
+ *    'hasInternalSpecifier': ...,
+ *    'internalSpecifiers': ...
+ * }, {
+ *    '@context': 'http://phyloref.org/curation-tool/json/phyx.json',
+ *    '@id': 'http://vocab.phyloref.org/clado/CLADO_PHYLOGENY_1',
+ *    '@type': 'cdao:???',
+ *    'includesNodes': [
+ *      {'@id': 'http://vocab.phyloref.org/clado/CLADO_PHYLOGENY_1_node1', ...},
+ *      {'@id': 'http://vocab.phyloref.org/clado/CLADO_PHYLOGENY_1_node2', ...}
+ *    ]
+ * }]
+ */
+const phylorefs = [];
+let specifiers = [];
+for (let phyxFile of jsons) {
+  for (let phyloref of phyxFile.phylorefs) {
+    entityIndex += 1;
+    const jsonld = new phyx.PhylorefWrapper(phyloref).exportAsJSONLD(getIdentifier(entityIndex));
+
+    jsonld['@context'] = PHYX_CONTEXT_JSON;
+    phylorefs.push(jsonld);
+  }
+}
+
+const phylogenies = [];
+for (var phyxFile of jsons) {
+  for (var phylogeny of phyxFile.phylogenies) {
+    entityIndex += 1;
+
+    // TODO: Add phylogeny, nodes and taxonomic units.
+    // TODO: Add matching to *all* specifiers.
+  }
+}
+
+const cladeOntology = [
+  {
+    '@context': PHYX_CONTEXT_JSON,
+    '@id': CLADE_ONTOLOGY_BASEURI,
+    '@type': 'owl:Ontology',
+    'owl:imports': [
+      'http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
+      'http://ontology.phyloref.org/phyloref.owl',
+      'http://purl.obolibrary.org/obo/bco.owl'
+    ]
+  }
+];
+console.log(JSON.stringify(
+  cladeOntology.concat(phylorefs).concat(phylogenies),
+  null,
+  4
+));

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -37,7 +37,6 @@ function convertTUtoRestriction(tunit) {
     return convertTUtoRestriction(tunit.referencesTaxonomicUnits[0] || {});
   }
 
-  // We can only do this for scientific names currently.
   const results = [];
   if(hasOwnProperty(tunit, 'scientificNames')) {
     tunit.scientificNames.forEach(sciname => {
@@ -59,6 +58,23 @@ function convertTUtoRestriction(tunit) {
         }
       });
     });
+  } else if(hasOwnProperty(tunit, 'includesSpecimens')) {
+    tunit.includesSpecimens.forEach(specimen => {
+      const wrappedSpecimen = new phyx.SpecimenWrapper(specimen);
+
+      results.push({
+        '@type': 'owl:Restriction',
+        'onProperty': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#circumscribedBy',
+        'someValuesFrom': {
+          '@type': 'owl:Restriction',
+          'onProperty': 'dwc:organismID', // TODO Technically, this should be a token. Probably.
+          'hasValue': wrappedSpecimen.occurrenceID
+        }
+      });
+    });
+  } else {
+    process.stderr.write(`WARNING: taxonomic unit could not be converted into restriction: ${JSON.stringify}`);
+    results.push({});
   }
 
   return results;

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -225,6 +225,26 @@ for (let phyxFile of jsons) {
           }
         ]
       }
+    } else if(internalSpecifiers.length === 2 && externalSpecifiers.length === 0) {
+      jsonld['equivalentClass'] = {
+        '@type': 'owl:Restriction',
+        'onProperty': 'obo:CDAO_0000149', // cdao:has_Child
+        'someValuesFrom': {
+          '@type': 'owl:Class',
+          'intersectionOf': [
+            {
+              '@type': 'owl:Restriction',
+              'onProperty': 'phyloref:excludes_TU',
+              'someValuesFrom': convertTUtoRestriction(internalSpecifiers[0])[0],
+            },
+            {
+              '@type': 'owl:Restriction',
+              'onProperty': 'phyloref:includes_TU',
+              'someValuesFrom': convertTUtoRestriction(internalSpecifiers[1])[0],
+            }
+          ]
+        }
+      }
     }
 
     jsonld['@context'] = PHYX_CONTEXT_JSON;

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -166,7 +166,7 @@ let specifiers = [];
 for (let phyxFile of jsons) {
   for (let phyloref of phyxFile.phylorefs) {
     entityIndex += 1;
-    const jsonld = new phyx.PhylorefWrapper(phyloref).exportAsJSONLD(getIdentifier(entityIndex));
+    const jsonld = new phyx.PhylorefWrapper(phyloref).asJSONLD(getIdentifier(entityIndex));
 
     jsonld['@context'] = PHYX_CONTEXT_JSON;
     phylorefs.push(jsonld);

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -492,6 +492,19 @@ for (let phyxFile of jsons) {
     // Step 1. Figure out what the node is for all our internal specifiers.
     if(internalSpecifiers.length === 0) {
       jsonld['malformedPhyloreference'] = "No internal specifiers provided";
+    } else if(internalSpecifiers.length === 1 && externalSpecifiers.length === 1) {
+      // We have a particularly compact form for this case!
+      jsonld['equivalentClass'] = {
+        '@type': 'owl:Class',
+        'intersectionOf': [
+          {
+            '@type': 'owl:Restriction',
+            'onProperty': 'phyloref:excludes_TU',
+            'someValuesFrom': convertTUtoRestriction(externalSpecifiers[0])[0],
+          },
+          getIncludesRestrictionForTU(internalSpecifiers[0])
+        ]
+      };
     } else {
       let expressionsForInternals = (internalSpecifiers.length === 1) ?
         [getIncludesRestrictionForTU(internalSpecifiers[0])] :

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -117,11 +117,14 @@ function findPHYXFiles(dirPath) {
 
 // Read command-line arguments.
 const argv = require('yargs')
-  .usage('Usage: $0 <directories or files to convert>')
+  .usage('Usage: $0 <directories or files to convert> [--no-phylogenies]')
   .demandCommand(1) // Make sure there's at least one directory or file!
+  .default('no-phylogenies', false)
   .help('h')
   .alias('h', 'help')
   .argv;
+
+const flag_no_phylogenies = argv.no_phylogenies
 
 // Unnamed arguments should be files or directories to be processed.
 const phyxFiles = argv._.map((filenameOrDirname) => {
@@ -636,8 +639,12 @@ const cladeOntology = [
     ],
   },
 ];
+let objs = cladeOntology.concat(phylorefs)
+if(!flag_no_phylogenies) {
+    objs = objs.concat(phylogenies)
+}
 console.log(JSON.stringify(
-  cladeOntology.concat(phylorefs).concat(phylogenies).concat(tunitMatches),
+  objs,
   null,
   4
 ));

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -30,25 +30,8 @@ global.moment = require('moment');
 global.jQuery = {};
 global.jQuery.extend = require('extend');
 
-// Load d3 as a global variable so it can be accessed by both phylotree.js (which
-// needs to add additional objects to it) and phyx.js (which needs to call it).
-global.d3 = require('d3');
-
-// Define hasOwnProperty() so we can use it on all classes.
-function hasOwnProperty(obj, key) {
-  return Object.prototype.hasOwnProperty.call(obj, key);
-}
-
-// phylotree.js does not export functions itself, but adds them to global.d3.layout.
-// So we set up a global.d3.layout object for them to be added to, and then we include
-// phylotree.js ourselves.
-if (!hasOwnProperty(global.d3, 'layout')) {
-  global.d3.layout = {};
-}
-require('../curation-tool/lib/phylotree.js/phylotree.js');
-
 // Load phyx.js, our PHYX library.
-const phyx = require('../curation-tool/js/phyx');
+const phyx = require('@phyloref/phyx');
 
 // Helper methods.
 

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -250,8 +250,8 @@ const cladeOntology = [
     '@type': 'owl:Ontology',
     'owl:imports': [
       'http://raw.githubusercontent.com/phyloref/curation-workflow/develop/ontologies/phyloref_testcase.owl',
-      'http://ontology.phyloref.org/phyloref.owl',
-      'http://purl.obolibrary.org/obo/bco.owl'
+      'http://ontology.phyloref.org/2018-12-14/phyloref.owl',
+      'http://ontology.phyloref.org/2018-12-14/tcan.owl',
     ]
   }
 ];

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -40,24 +40,24 @@ function convertTUtoRestriction(tunit) {
   // We can only do this for scientific names currently.
   const results = [];
   if(hasOwnProperty(tunit, 'scientificNames')) {
-    tunit.scientificNames.forEach(name => {
-      if(hasOwnProperty(name, 'binomialName') || hasOwnProperty(name, 'scientificName')) {
-        results.push({
-          '@type': 'owl:Restriction',
-          'onProperty': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
-          'someValuesFrom': {
-            '@type': 'owl:Class',
-            'intersectionOf': [
-              { '@id':'obo:NOMEN_0000107' }, // ICZN -- TODO replace with a check once we close phyloref/phyx.js#5.
-              {
-                '@type':'owl:Restriction',
-                'onProperty': 'dwc:scientificName',
-                'hasValue': name['binomialName'] || name['scientificName'], // TODO: We really want the "canonical name" here: binomial or trinomial, but without any additional authority information.
-              }
-            ]
-          }
-        });
-      }
+    tunit.scientificNames.forEach(sciname => {
+      const wrappedSciname = new phyx.ScientificNameWrapper(sciname);
+
+      results.push({
+        '@type': 'owl:Restriction',
+        'onProperty': 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
+        'someValuesFrom': {
+          '@type': 'owl:Class',
+          'intersectionOf': [
+            { '@id':'obo:NOMEN_0000107' }, // ICZN -- TODO replace with a check once we close phyloref/phyx.js#5.
+            {
+              '@type':'owl:Restriction',
+              'onProperty': 'dwc:scientificName',
+              'hasValue': wrappedSciname.binomialName, // TODO: We really want the "canonical name" here: binomial or trinomial, but without any additional authority information.
+            }
+          ]
+        }
+      });
     });
   }
 

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -614,7 +614,8 @@ phylorefs.forEach((phylorefAsParam) => {
   });
 });
 
-const cladeOntology = [
+/* Construct an object to represent the Clade Ontology itself. */
+let cladeOntologyObjects = [
   {
     '@context': PHYX_CONTEXT_JSON,
     '@id': CLADE_ONTOLOGY_BASEURI,
@@ -626,12 +627,16 @@ const cladeOntology = [
     ],
   },
 ];
-let objs = cladeOntology.concat(phylorefs);
+
+/* Add all the phyloreferences and phylogenies to the JSON-LD file being prepared. */
+cladeOntologyObjects = cladeOntologyObjects.concat(phylorefs);
 if (!argv.no_phylogenies) { // if the --no-phylogenies command line option was NOT true
-  objs = objs.concat(phylogenies);
+  cladeOntologyObjects = cladeOntologyObjects.concat(phylogenies);
 }
+
+/* Write the list of Clade Ontology objects to STDOUT. */
 process.stdout.write(JSON.stringify(
-  objs,
+  cladeOntologyObjects,
   null,
   4
 ));

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -173,7 +173,6 @@ jsons.forEach((phyxFile) => {
 });
 
 const phylogenies = [];
-const tunitMatches = [];
 jsons.forEach((phyxFile) => {
   phyxFile.phylogenies.forEach((phylogeny) => {
     entityIndex += 1;
@@ -243,46 +242,6 @@ jsons.forEach((phyxFile) => {
 
     phylogenyAsJSONLD['@context'] = PHYX_CONTEXT_JSON;
     phylogenies.push(phylogenyAsJSONLD);
-  });
-});
-
-phylorefs.forEach((phylorefAsParam) => {
-  const phyloref = phylorefAsParam;
-
-  let specifiers = [];
-  if (has(phyloref, 'internalSpecifiers')) specifiers = phyloref.internalSpecifiers;
-  if (has(phyloref, 'externalSpecifiers')) specifiers = specifiers.concat(phyloref.externalSpecifiers);
-
-  specifiers.forEach((specifier) => {
-    let countMatchedNodes = 0;
-
-    if (has(specifier, 'referencesTaxonomicUnits')) {
-      specifier.referencesTaxonomicUnits.forEach((specifierTU) => {
-        phylogenies.forEach((phylogenyAsJSONLD) => {
-          phylogenyAsJSONLD.nodes.forEach((node) => {
-            if (!has(node, 'representsTaxonomicUnits')) return;
-
-            node.representsTaxonomicUnits.forEach((nodeTU) => {
-              const matcher = new phyx.TaxonomicUnitMatcher(specifierTU, nodeTU);
-              if (matcher.matched) {
-                entityIndex += 1;
-                const tuMatchAsJSONLD = matcher.asJSONLD(getIdentifier(entityIndex));
-
-                countMatchedNodes += 1;
-                tuMatchAsJSONLD['@context'] = PHYX_CONTEXT_JSON;
-                tunitMatches.push(tuMatchAsJSONLD);
-              }
-            });
-          });
-        });
-      });
-
-      // If this specifier could not be matched, record it as an unmatched specifier.
-      if (countMatchedNodes === 0) {
-        if (!has(phyloref, 'hasUnmatchedSpecifiers')) phyloref.hasUnmatchedSpecifiers = [];
-        phyloref.hasUnmatchedSpecifiers.push({ '@id': specifier['@id'] });
-      }
-    }
   });
 });
 

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -168,11 +168,15 @@ for (let phyxFile of jsons) {
     entityIndex += 1;
     const phylogenyAsJSONLD = new phyx.PhylogenyWrapper(phylogeny).asJSONLD(getIdentifier(entityIndex));
 
-    // For every internal node in this phylogeny, check to see if it's expected to
-    // resolve to a phylogeny we know about. If so, add an rdf:type to that effect.
     (phylogenyAsJSONLD.nodes || []).forEach(node => {
-      // Check the node label.
-      const expectedToResolveTo = node.labels || [];
+      // For every internal node in this phylogeny, check to see if it's expected to
+      // resolve to a phylogeny we know about. If so, add an rdf:type to that effect.
+      let expectedToResolveTo = node.labels || [];
+
+      // Are there any phyloreferences expected to resolve here?
+      if(hasOwnProperty(node, 'expectedPhyloreferenceNamed')) {
+        expectedToResolveTo = expectedToResolveTo.concat(node.expectedPhyloreferenceNamed);
+      }
 
       expectedToResolveTo.forEach(phylorefLabel => {
         if(!hasOwnProperty(phylorefsByLabel, phylorefLabel)) return;

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -9,7 +9,7 @@
  */
 
 // Configuration options.
-const PHYX_CONTEXT_JSON = 'http://www.phyloref.org/curation-tool/json/phyx.json';
+const PHYX_CONTEXT_JSON = 'http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json';
 const CLADE_ONTOLOGY_BASEURI = 'http://phyloref.org/clade-ontology/clado.owl';
 
 // Load necessary modules.

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -512,6 +512,10 @@ for (let phyxFile of jsons) {
       if(!hasOwnProperty(node, '@type')) node['@type'] = [];
       if(!Array.isArray(node['@type'])) node['@type'] = [node['@type']];
 
+      // TODO remove hack: replace "parent" with "obo:CDAO_0000179" so we get has_Parent
+      // relationships in our output ontology.
+      if(hasOwnProperty(node, 'parent')) node['obo:CDAO_0000179'] = { '@id': node.parent };
+
       // For every internal node in this phylogeny, check to see if it's expected to
       // resolve to a phylogeny we know about. If so, add an rdf:type to that effect.
       let expectedToResolveTo = node.labels || [];

--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -18,102 +18,41 @@ const { has } = require('lodash');
 // Load phyx.js, our PHYX library.
 const phyx = require('@phyloref/phyx');
 
-/*
- * convertTUtoRestriction(tunit)
- *  - tunit: A taxonomic unit (or a specifier containing at least one taxonomic unit)
- *
- * Converts a taxonomic unit to a list of OWL restrictions, in the form of:
- *  tc:hasName some (ICZN_Name and dwc:scientificName value "scientific name")
- * or:
- *  tc:circumscribedBy some (dwc:organismID value "occurrence ID")
- *
-* This method will be moved back into phyx.js as part of https://github.com/phyloref/phyx.js/issues/4
- */
-function convertTUtoRestriction(tunit) {
-  // If we're called with a specifier, use the first TU in that specifier (for now).
-  if (has(tunit, 'referencesTaxonomicUnits')) {
-    return convertTUtoRestriction(tunit.referencesTaxonomicUnits[0] || {});
-  }
-
-  // Build up a series of taxonomic units from scientific names and specimens.
-  const results = [];
-  if (has(tunit, 'scientificNames')) {
-    tunit.scientificNames.forEach((sciname) => {
-      const wrappedSciname = new phyx.ScientificNameWrapper(sciname);
-
-      results.push({
-        '@type': 'owl:Restriction',
-        onProperty: 'http://rs.tdwg.org/ontology/voc/TaxonConcept#hasName',
-        someValuesFrom: {
-          '@type': 'owl:Class',
-          intersectionOf: [
-            {
-              // TODO: replace with a check once we close https://github.com/phyloref/phyx.js/issues/5.
-              // For now, we pretend that all names are ICZN names.
-              '@id': 'obo:NOMEN_0000107',
-            },
-            {
-              '@type': 'owl:Restriction',
-              onProperty: 'dwc:scientificName',
-              // TODO: We really want the "canonical name" here: binomial or
-              // trinomial, but without any additional authority information.
-              // See https://github.com/phyloref/phyx.js/issues/8
-              hasValue: wrappedSciname.binomialName,
-            },
-          ],
-        },
-      });
-    });
-  }
-
-  if (has(tunit, 'includesSpecimens')) {
-    // This is a quick-and-dirty implementation. Discussion about it should be
-    // carried out in https://github.com/phyloref/clade-ontology/issues/61
-    tunit.includesSpecimens.forEach((specimen) => {
-      const wrappedSpecimen = new phyx.SpecimenWrapper(specimen);
-
-      results.push({
-        '@type': 'owl:Restriction',
-        onProperty: 'dwc:organismID',
-        hasValue: wrappedSpecimen.occurrenceID,
-      });
-    });
-  } else {
-    process.stderr.write(`WARNING: taxonomic unit could not be converted into restriction: ${JSON.stringify}`);
-    results.push({});
-  }
-
-  return results;
-}
+// Load some methods we use to convert from Model 1.0 to Model 2.0 on the fly.
+// These will be moved into phyx.js in https://github.com/phyloref/phyx.js/issues/4
+const {
+  convertTUtoRestriction,
+  getIncludesRestrictionForTU,
+  createClassExpressionsForInternals,
+  createClassExpressionsForExternals,
+} = require('./model2.js');
 
 /*
  * Returns a list of PHYX files that we can test in the provided directory.
- *
- * This could be implemented asynchronously, but we need a list of files to
- * test each one individually in Mocha, so we need a synchronous implementation
- * to get that list before we start testing.
  */
 function findPHYXFiles(dirPath) {
+  // Read all files from the provided directory and look for '.json' files.
   const filesFound = fs.readdirSync(dirPath).map((filename) => {
     const filePath = path.join(dirPath, filename);
 
     const stats = fs.statSync(filePath);
     if (stats.isDirectory()) {
-      // Recurse into this directory.
+      // Recurse into every directory in the provided directory.
       return findPHYXFiles(filePath);
-    }
-
-    if (!stats.isFile()) {
-      throw new Error(`Attempted to select non-file object: ${filePath}`);
     }
 
     // Look for .json files (but not for '_as_owl.json' files, for historical reasons).
     if (filePath.endsWith('.json') && !filePath.endsWith('_as_owl.json')) {
       return [filePath];
     }
+
     return [];
   }).reduce((x, y) => x.concat(y), []); // This flattens the list of results.
+
+  // If no files could be found, the user might have made a mistake by entering
+  // the wrong directory name, so let them know that it failed.
   if (filesFound.length === 0) process.stderr.write(`Warning: directory ${dirPath} contains no JSON files.`);
+
   return filesFound;
 }
 
@@ -122,14 +61,15 @@ const argv = require('yargs')
   .usage('Usage: $0 <directories or files to convert> [--no-phylogenies]')
   .demandCommand(1) // Make sure there's at least one directory or file!
   .option('no-phylogenies', {
+    // --no-phylogenies: Flag for turning off including phylogenies in the produced ontology.
     describe: 'Do not include phylogenies in the produced ontology',
+    default: false,
   })
-  .default('no-phylogenies', false)
   .help('h')
   .alias('h', 'help')
   .argv;
 
-// Unnamed arguments maybe files or directories to be processed.
+// Treat unnamed commands as files or directories to be scanned for JSON files.
 const phyxFiles = argv._.map((filenameOrDirname) => {
   const stats = fs.statSync(filenameOrDirname);
   if (stats.isDirectory()) return findPHYXFiles(filenameOrDirname);
@@ -142,6 +82,7 @@ if (phyxFiles.length === 0) throw new Error('No arguments provided!');
 /* Start producing the output ontology */
 
 // Every entity in the output ontology should have a unique CLADO identifier.
+// getIdentifier() provides these.
 let entityIndex = 0;
 function getIdentifier(index) {
   return `${CLADE_ONTOLOGY_BASEURI}#CLADO_${index.toString().padStart(8, '0')}`;
@@ -171,275 +112,6 @@ const jsons = phyxFiles
   .reduce((a, b) => a.concat(b), []);
 
 const phylorefsByLabel = {};
-
-let additionalClassCount = 0;
-const additionalClassesByLabel = {};
-function createAdditionalClass(jsonld, internalSpecifiers, externalSpecifiers, equivClassFunc) {
-  // This function creates an additional class for the set of internal and external
-  // specifiers provided for the equivalentClass expression provided. If one already
-  // exists for this set of internal and external specifiers, we just return that
-  // instead of creating a new one.
-  //
-  // For some reason this acts strange if equivalentClass is a string, so instead
-  // I've made it into a function here.
-
-  if (internalSpecifiers.length === 0) throw new Error('Cannot create additional class without any internal specifiers');
-  if (internalSpecifiers.length === 1 && externalSpecifiers.length === 0) throw new Error('Cannot create additional class with a single internal specifiers and no external specifiers');
-
-  // TODO We need to replace this with an actual object-based comparison,
-  // rather than trusting the labels to tell us everything.
-  const externalSpecifierLabel = ` ~ ${externalSpecifiers
-    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
-    .sort()
-    .join(' V ')}`;
-
-  // Add the internal specifiers to this.
-  const additionalClassLabel = `(${internalSpecifiers
-    .map(i => convertTUtoRestriction(i)[0].someValuesFrom.intersectionOf[1].hasValue || '(error)')
-    .sort()
-    .join(' & ')
-  }${externalSpecifiers.length > 0 ? externalSpecifierLabel : ''
-  })`;
-
-  process.stderr.write(`Additional class label: ${additionalClassLabel}\n`);
-
-  if (has(additionalClassesByLabel, additionalClassLabel)) {
-    process.stderr.write(`Found additional class with id: ${additionalClassesByLabel[additionalClassLabel]['@id']}\n`);
-    return { '@id': additionalClassesByLabel[additionalClassLabel]['@id'] };
-  }
-
-  additionalClassCount += 1;
-  const additionalClass = {};
-  additionalClass['@id'] = `${jsonld['@id']}_additional${additionalClassCount}`;
-  process.stderr.write(`Creating new additionalClass with id: ${additionalClass['@id']}`);
-
-  additionalClass['@type'] = 'owl:Class';
-  additionalClass.subClassOf = (
-    externalSpecifiers.length > 0 ? 'phyloref:PhyloreferenceUsingMinimumClade' : 'phyloref:PhyloreferenceUsingMaximumClade'
-  );
-  additionalClass.equivalentClass = equivClassFunc();
-  additionalClass.label = additionalClassLabel;
-  jsonld.hasAdditionalClass.push(additionalClass);
-
-  additionalClassesByLabel[additionalClassLabel] = additionalClass;
-
-  return { '@id': additionalClass['@id'] };
-}
-
-function getIncludesRestrictionForTU(tu) {
-  return {
-    '@type': 'owl:Restriction',
-    onProperty: 'phyloref:includes_TU',
-    someValuesFrom: convertTUtoRestriction(tu)[0],
-  };
-}
-
-function getMRCA2Expression(tu1, tu2) {
-  return {
-    '@type': 'owl:Restriction',
-    onProperty: 'obo:CDAO_0000149', // cdao:has_Child
-    someValuesFrom: {
-      '@type': 'owl:Class',
-      intersectionOf: [
-        {
-          '@type': 'owl:Restriction',
-          onProperty: 'phyloref:excludes_TU',
-          someValuesFrom: convertTUtoRestriction(tu1)[0],
-        },
-        getIncludesRestrictionForTU(tu2),
-      ],
-    },
-  };
-}
-
-function createClassExpressionsForInternals(jsonld, remainingInternals, selected) {
-  // Create a class expression for a phyloref made up entirely of internal specifiers.
-  //  - additionalClasses: used to store additional classes as needed.
-  //  - remainingInternals: taxonomic units remaining to be included.
-  //  - selected: taxonomic units that have been selected already.
-
-  // This algorithm works like this:
-  //  - 1. We start with everything remaining and nothing selected.
-  //  - 2. We recurse into this method, moving everything in remaining into selected one by one.
-  //    - Think of it as a tree: the root node selects each internal once, and then each child node
-  //      selects one additional item from remaining, and so on.
-  process.stderr.write(`@id [${jsonld['@id']}] Remaining internals: ${remainingInternals.length}, selected: ${selected.length}\n`);
-
-  // Quick special case: if we have two 'remainingInternals' and zero selecteds,
-  // we can just return the MRCA for two internal specifiers.
-  if (selected.length === 0) {
-    if (remainingInternals.length === 2) {
-      return [getMRCA2Expression(remainingInternals[0], remainingInternals[1])];
-    } if (remainingInternals.length === 1) {
-      throw new Error('Cannot determine class expression for a single specifier');
-    } else if (remainingInternals.length === 0) {
-      throw new Error('Cannot determine class expression for zero specifiers');
-    }
-  }
-
-  // Step 1. If we've already selected something, create an expression for it.
-  const classExprs = [];
-  if (selected.length > 0) {
-    let remainingInternalsExpr = [];
-    if (remainingInternals.length === 1) {
-      remainingInternalsExpr = getIncludesRestrictionForTU(remainingInternals[0]);
-    } else if (remainingInternals.length === 2) {
-      remainingInternalsExpr = getMRCA2Expression(remainingInternals[0], remainingInternals[1]);
-    } else {
-      remainingInternalsExpr = createAdditionalClass(
-        jsonld,
-        remainingInternals,
-        [],
-        () => createClassExpressionsForInternals(jsonld, remainingInternals, [])
-      );
-    }
-
-    let selectedExpr = [];
-    if (selected.length === 1) {
-      selectedExpr = getIncludesRestrictionForTU(selected[0]);
-    } else if (selected.length === 2) {
-      selectedExpr = getMRCA2Expression(selected[0], selected[1]);
-    } else {
-      selectedExpr = createAdditionalClass(
-        jsonld,
-        selected,
-        [],
-        () => createClassExpressionsForInternals(jsonld, selected, [])
-      );
-    }
-
-    classExprs.push({
-      '@type': 'owl:Restriction',
-      onProperty: 'obo:CDAO_0000149', // cdao:has_Child
-      someValuesFrom: {
-        '@type': 'owl:Class',
-        intersectionOf: [{
-          '@type': 'owl:Restriction',
-          onProperty: 'phyloref:excludes_lineage_to',
-          someValuesFrom: remainingInternalsExpr,
-        }, selectedExpr],
-      },
-    });
-  }
-
-  // Step 2. Now select everything from remaining once, and start recursing through
-  // every possibility.
-  // Note that we only process cases where there are more remainingInternals than
-  // selected internals -- when there are fewer, we'll just end up with the inverses
-  // of the previous comparisons, which we'll already have covered.
-  // TODO: the other way around that would be to wrap *everything* into additional
-  // classes, which might be a useful thing to do anyway.
-  if (remainingInternals.length > 1 && selected.length <= remainingInternals.length) {
-    remainingInternals.map((newlySelected) => {
-      process.stderr.write(`Selecting new object, remaining now at: ${remainingInternals.filter(i => i !== newlySelected).length}, selected: ${selected.concat([newlySelected]).length}\n`);
-      return createClassExpressionsForInternals(
-        jsonld,
-        // The new remaining is the old remaining minus the selected TU.
-        remainingInternals.filter(i => i !== newlySelected),
-        // The new selected is the old selected plus the selected TU.
-        selected.concat([newlySelected])
-      );
-    })
-      .reduce((acc, val) => acc.concat(val), [])
-      .forEach(expr => classExprs.push(expr));
-  }
-
-  return classExprs;
-}
-
-function getExclusionsForExprAndTU(includedExpr, tu) {
-  if (!includedExpr) throw new Error('Exclusions require an included expression');
-
-  const exprs = [{
-    '@type': 'owl:Class',
-    intersectionOf: [
-      includedExpr,
-      {
-        '@type': 'owl:Restriction',
-        onProperty: 'phyloref:excludes_TU',
-        someValuesFrom: convertTUtoRestriction(tu)[0],
-      },
-    ],
-  }];
-
-  if (!Array.isArray(includedExpr) && has(includedExpr, 'onProperty') && includedExpr.onProperty === 'phyloref:includes_TU') {
-    // In this specific set of circumstances, we do NOT need to add the has_Ancestor check.
-  } else {
-    // Add the has_Ancestor check!
-    exprs.push({
-      '@type': 'owl:Class',
-      intersectionOf: [
-        includedExpr,
-        {
-          '@type': 'owl:Restriction',
-          onProperty: 'obo:CDAO_0000144', // has_Ancestor
-          someValuesFrom: {
-            '@type': 'owl:Restriction',
-            onProperty: 'phyloref:excludes_TU',
-            someValuesFrom: convertTUtoRestriction(tu)[0],
-          },
-        },
-      ],
-    });
-  }
-
-  return exprs;
-}
-
-function createClassExpressionsForExternals(jsonld, accumulatedExpr, remainingExternals, selected) {
-  // When creating a class expression with external specifiers, we can treat the
-  // internal expression as evaluating to a particular set of nodes. Each external
-  // specifier can have one of two relationships with the internal expression node:
-  //  - It could directly excludes_TU the external specifier, or
-  //  - It could have an ancestor that excludes_TU the external specifier.
-  // For the single case, this is straightforward. But when there are multiple
-  // external specifiers, we must use the same recursive algorithm we use to
-  // ensure that we try them out in every possible combination.
-  process.stderr.write(`@id [${jsonld['@id']}] Remaining externals: ${remainingExternals.length}, selected: ${selected.length}\n`);
-
-  // Step 1. If we only have one external remaining, we can provide our two-case example
-  // to detect it.
-  const classExprs = [];
-  if (remainingExternals.length === 0) {
-    throw new Error('Cannot create class expression when no externals remain');
-  } else if (remainingExternals.length === 1) {
-    const remainingExternalsExprs = getExclusionsForExprAndTU(
-      accumulatedExpr,
-      remainingExternals[0],
-      selected.length > 0
-    );
-    remainingExternalsExprs.forEach(expr => classExprs.push(expr));
-  } else { // if(remainingExternals.length > 1)
-    // Recurse into remaining externals. Every time we select a single entry,
-    // we create a class expression for that.
-    remainingExternals.map((newlySelected) => {
-      process.stderr.write(`Selecting new object, remaining now at: ${remainingExternals.filter(i => i !== newlySelected).length}, selected: ${selected.concat([newlySelected]).length}\n`);
-
-      const newlyAccumulatedExpr = createAdditionalClass(
-        jsonld,
-        jsonld.internalSpecifiers,
-        selected.concat([newlySelected]),
-        () => getExclusionsForExprAndTU(accumulatedExpr, newlySelected, selected.length > 0)
-      );
-
-      return createClassExpressionsForExternals(
-        jsonld,
-        newlyAccumulatedExpr,
-        // The new remaining is the old remaining minus the selected TU.
-        remainingExternals.filter(i => i !== newlySelected),
-        // The new selected is the old selected plus the selected TU.
-        selected.concat([newlySelected])
-      );
-    })
-      .reduce((acc, val) => acc.concat(val), [])
-      .forEach(expr => classExprs.push(expr));
-  }
-
-  // console.dir(classExprs, { depth: null })
-
-  return classExprs;
-}
-
 const phylorefs = [];
 jsons.forEach((phyxFile) => {
   phyxFile.phylorefs.forEach((phyloref) => {

--- a/test/test_phyx2ontology.js
+++ b/test/test_phyx2ontology.js
@@ -1,0 +1,30 @@
+/*
+ * test_phyx2ontology.js: Test whether phyx2ontology.js can be executed successfully.
+ */
+
+const BASE_DIR = 'phyx/';
+
+// Javascript libraries.
+const ChildProcess = require('child_process');
+const chai = require('chai');
+
+const assert = chai.assert;
+
+describe('Executing phyx2ontology.js on all current Phyx files', function () {
+  const child = ChildProcess.spawnSync('node', [
+    'phyx2ontology/phyx2ontology.js', BASE_DIR,
+  ]);
+
+  it('should execute successfully', function () {
+    assert.equal(child.status, 0, 'Exit value should be zero');
+    assert.isEmpty(child.stderr, 'Should not produce any output to STDERR');
+  });
+
+  it('should produce valid JSON output', function () {
+    let json = [];
+    assert.doesNotThrow(function () {
+      json = JSON.parse(child.stdout);
+    }, SyntaxError, 'Produced JSON should be parsable');
+    assert.isNotEmpty(json, 'Produced JSON should not be empty');
+  });
+});


### PR DESCRIPTION
This PR adds a script that can be used to create a synthesized Clade Ontology from the Phyx files in this repository. It currently generates an OWL 2 DL JSON-LD representation using phyx.js, and then converts it into a OWL 2 EL JSON-LD representation on the fly. I will eventually move this code into phyx.js, but only after JPhyloRef has been updated to be able to test OWL files using OWL 2 EL reasoners.

WIP -- this code is still very quick-and-dirty and will need a bunch of cleanup before it's ready for review. Also, there are still some bugs in the output -- for example, "Tomistominae (alt)" resolves to *two* nodes on the same phylogeny, which should be impossible -- so these should be fixed before this PR is reviewed.

Should be merged after PR #60 has been merged.