### PR TITLE
Create regnum2phyx script to convert Regnum database dumps to Phyx files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
         "es6": true
     },
     "plugins": [
-        "mocha"
+        "mocha",
+        "json"
     ],
     "rules": {
       "prefer-destructuring": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,7 +1677,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -1817,7 +1817,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "1.0.2",
@@ -1839,7 +1839,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "1.1.0",
@@ -1849,7 +1849,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "2.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,9 +54,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "2.0.1",
@@ -364,7 +364,7 @@
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "ajv": "6.9.2",
+        "ajv": "6.10.0",
         "chalk": "2.4.2",
         "cross-spawn": "6.0.5",
         "debug": "4.1.1",
@@ -508,6 +508,15 @@
             "isarray": "1.0.0"
           }
         }
+      }
+    },
+    "eslint-plugin-json": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.4.0.tgz",
+      "integrity": "sha512-CECvgRAWtUzuepdlPWd+VA7fhyF9HT183pZnl8wQw5x699Mk/MbME/q8xtULBfooi3LUbj6fToieNmsvUcDxWA==",
+      "dev": true,
+      "requires": {
+        "vscode-json-languageservice": "3.2.1"
       }
     },
     "eslint-plugin-mocha": {
@@ -985,6 +994,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "jsonc-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.1.0.tgz",
+      "integrity": "sha512-n9GrT8rrr2fhvBbANa1g+xFmgGK5X91KFeDwlKQ3+SJfmH5+tKv/M/kahx/TXOMflfWHKGKqKyfHQaLKTNzJ6w==",
       "dev": true
     },
     "lcid": {
@@ -1701,7 +1716,7 @@
       "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.9.2",
+        "ajv": "6.10.0",
         "lodash": "4.17.11",
         "slice-ansi": "2.1.0",
         "string-width": "3.0.0"
@@ -1795,6 +1810,36 @@
         "spdx-correct": "3.1.0",
         "spdx-expression-parse": "3.0.0"
       }
+    },
+    "vscode-json-languageservice": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.2.1.tgz",
+      "integrity": "sha512-ee9MJ70/xR55ywvm0bZsDLhA800HCRE27AYgMNTU14RSg20Y+ngHdQnUt6OmiTXrQDI/7sne6QUOtHIN0hPQYA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "2.1.0",
+        "vscode-languageserver-types": "3.14.0",
+        "vscode-nls": "4.1.0",
+        "vscode-uri": "1.0.6"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
+      "integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.0.tgz",
+      "integrity": "sha512-zKsFWVzL1wlCezgaI3XiN42IT8DIPM1Qr+G+RBhiU3U0bJCdC8pPELakRCtuVT4wF3gBZjBrUDQ8mowL7hmgwA==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,9 +135,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "chai": {
       "version": "4.2.0",
@@ -307,8 +307,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -724,9 +723,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -1041,19 +1040,27 @@
       }
     },
     "mem": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "requires": {
         "map-age-cleaner": "0.1.3",
-        "mimic-fn": "1.2.0",
-        "p-is-promise": "2.0.0"
+        "mimic-fn": "2.1.0",
+        "p-is-promise": "2.1.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        }
       }
     },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1219,7 +1226,7 @@
       "requires": {
         "execa": "1.0.0",
         "lcid": "2.0.0",
-        "mem": "4.1.0"
+        "mem": "4.3.0"
       }
     },
     "os-tmpdir": {
@@ -1239,16 +1246,16 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-is-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
     },
     "p-limit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "requires": {
-        "p-try": "2.0.0"
+        "p-try": "2.2.0"
       }
     },
     "p-locate": {
@@ -1256,13 +1263,13 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "2.1.0"
+        "p-limit": "2.2.0"
       }
     },
     "p-try": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parent-module": {
       "version": "1.0.0",
@@ -1490,9 +1497,9 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.10.0",
@@ -1670,7 +1677,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -1810,7 +1817,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "1.0.2",
@@ -1832,7 +1839,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "1.1.0",
@@ -1842,7 +1849,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "2.1.1"
@@ -1870,30 +1877,54 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
       "requires": {
         "cliui": "4.1.0",
-        "decamelize": "1.2.0",
         "find-up": "3.0.0",
-        "get-caller-file": "1.0.3",
+        "get-caller-file": "2.0.5",
         "os-locale": "3.1.0",
         "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
+        "require-main-filename": "2.0.0",
         "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
+        "string-width": "3.1.0",
         "which-module": "2.0.0",
         "y18n": "4.0.0",
-        "yargs-parser": "11.1.1"
+        "yargs-parser": "13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "4.1.0"
+          }
+        }
       }
     },
     "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
       "requires": {
-        "camelcase": "5.0.0",
+        "camelcase": "5.3.1",
         "decamelize": "1.2.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^5.12.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-json": "^1.4.0",
     "eslint-plugin-mocha": "^5.2.1",
     "mocha": "^5.2.0",
     "tmp": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "yargs": "^13.2.1"
   },
   "devDependencies": {
+    "ajv": "^6.10.0",
     "chai": "^4.2.0",
     "eslint": "^5.12.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint \"test/**\" \"phyx2ontology/**\" \"regnum2phyx/**\" --ext .js",
     "pretest": "npm run lint",
-    "test": "mocha",
+    "test": "mocha --recursive",
     "mocha": "mocha",
     "build-ontology": "node phyx2ontology/phyx2ontology.js phyx/ > CLADO.json"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint \"test/**\" \"phyx2ontology/**\" \"regnum2phyx/**\" --ext .js",
     "pretest": "npm run lint",
     "test": "mocha",
+    "mocha": "mocha",
     "build-ontology": "node phyx2ontology/phyx2ontology.js phyx/ > CLADO.json"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "directories": {},
   "scripts": {
-    "lint": "eslint \"test/**\" \"phyx2ontology/**\" --ext .js",
+    "lint": "eslint \"test/**\" \"phyx2ontology/**\" \"regnum2phyx/**\" --ext .js",
     "pretest": "npm run lint",
     "test": "mocha",
     "build-ontology": "node phyx2ontology/phyx2ontology.js phyx/ > CLADO.json"
@@ -23,7 +23,7 @@
   "dependencies": {
     "@phyloref/phyx": "^0.1.2",
     "lodash": "^4.17.11",
-    "yargs": "^12.0.5"
+    "yargs": "^13.2.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -104,7 +104,7 @@ function convertCitationsToBibJSON(citation) {
     type,
     title: (citation.title || '').trim(),
     section_title: (citation.section_title || '').trim(),
-    year: (citation.year || '').trim(),
+    year: Number((citation.year || '')),
     edition: (citation.edition || '').trim(),
     authors: convertAuthorsIntoBibJSON(citation.authors),
     editors: convertAuthorsIntoBibJSON(citation.editors || []),

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -169,8 +169,8 @@ const argv = yargs
 // Read the database dump.
 const dump = JSON.parse(fs.readFileSync(argv._[0], 'utf8'));
 
-// This dump consists of multiple named phyloreferences, each of which should be
-// written out to a separate file.
+// This dump consists of multiple named phylogenetic clade definitions,
+// each of which should be written out to a separate file.
 const phyxProduced = {};
 let countErrors = 0;
 

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -87,7 +87,10 @@ function convertCitationsToBibJSON(citation) {
   }
 
   // Assume a default type of 'article' if none was provided.
-  const type = citation.citation_type || 'article';
+  let type = citation.citation_type || 'article';
+
+  // Regnum uses 'journal' where BibJSON uses 'article'.
+  if (type === 'journal') type = 'article';
 
   // In BibJSON, identifiers are kept separate from URLs.
   const identifiers = [];
@@ -120,7 +123,7 @@ function convertCitationsToBibJSON(citation) {
     if (citation.isbn) {
       identifiers.push({ type: 'isbn', id: citation.isbn });
     }
-  } else if (type === 'journal') {
+  } else if (type === 'article') {
     // Identify journal identifiers, such as the
     const journalIdentifiers = [];
     if (citation.isbn) {

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -1,7 +1,11 @@
 /*
  * regnum2phyx.js: A tool for converting PhyloRegnum database dumps to Phyx files.
  *
- * Synopsis: regnum2phyx.js [JSON file to process] -o [directory to write files to]
+ * Synopsis:
+ *  regnum2phyx.js [JSON file to process] -o [directory to write files to]
+ *
+ * Note that existing files in the output directory will be silently overwritten,
+ * so this script should usually be run on a new, empty output directory.
  *
  * PhyloRegnum can be accessed at http://app.phyloregnum.org
  */
@@ -10,13 +14,19 @@
 const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
-const { has, keys, pickBy } = require('lodash');
+const {
+  has, keys, pickBy, isEmpty,
+} = require('lodash');
 
 // Helper functions.
 function convertAuthorsIntoStrings(authors, lastNameFirst = true) {
-  // We combine authors as $first_name $middle_name $last_name.
-  // We could instead use foaf:firstName and foaf:lastName, but that's probably
-  // unnecessary (http://xmlns.com/foaf/spec/#term_firstName).
+  // Given a list of authors with first_name, middle_name and last_name properties,
+  // return a list of author names with a single name.
+  //
+  // We combine author names in two possible ways:
+  //  If lastNameFirst is true: $first_name $middle_name $last_name
+  //  If lastNameFirst is false: $last_name, $first_name $middle_name
+  // The middle name will be ignored if it is blank or not present.
 
   if (lastNameFirst) {
     // Use "last first middle".
@@ -35,10 +45,12 @@ function convertAuthorsIntoStrings(authors, lastNameFirst = true) {
   )).filter(name => name !== '');
 }
 
-function convertAuthorsIntoObjects(authors) {
+function convertAuthorsIntoBibJSON(authors) {
+  // Convert a list of authors in the Regnum dump format into a list of authors
+  // in the BibJSON format. Names without a last name will be ignored.
   return authors
     .filter(author => author.last_name)
-    .map(author => ({
+    .map(author => pickBy({ // lodash.pickBy will remove empty keys from the object.
       name: `${author.last_name || ''}, ${author.first_name || ''}${
         ((has(author, 'middle_name') && author.middle_name.trim() !== '') ? ` ${author.middle_name}` : '')
       }`.trim(),
@@ -53,25 +65,18 @@ function convertAuthorsIntoObjects(authors) {
     }));
 }
 
-function convertCitation(citation) {
-  // Convert a citation from its Regnum format into an ontologized form.
-  // We rely on BIBO (https://github.com/structureddynamics/Bibliographic-Ontology-BIBO)
-  // quite extensively for this.
+function convertCitationsToBibJSON(citation) {
+  // Convert a citation from its Regnum representation into the
+  // BibJSON format (http://okfnlabs.org/bibjson/). We use this rather than
+  // CSL-JSON (https://github.com/citation-style-language/schema) because it's
+  // easier to set up. We might want to switch over to CSL-JSON
+  // eventually (https://github.com/phyloref/clade-ontology/issues/69).
 
   if (!citation) return [];
   if (Array.isArray(citation)) {
-    return citation.map(c => convertCitation(c)).reduce((acc, val) => acc.concat(val), []);
-  }
-
-  // Figure out the citation type.
-  const citationTypes = {
-    journal: 'bibo:Article',
-    book: 'bibo:Book',
-    book_section: 'bibo:BookSection',
-  };
-  const citationType = citationTypes[citation.citation_type || 'journal'];
-  if (!citationType) {
-    throw new Error(`Unknown citation type: '${citation.citation_type}'`);
+    // If given an array of citation objects, convert each one separately.
+    return citation.map(c => convertCitationsToBibJSON(c))
+      .reduce((acc, val) => acc.concat(val), []);
   }
 
   // Do we have a title and a year? If not, skip this entry.
@@ -79,10 +84,10 @@ function convertCitation(citation) {
     return [];
   }
 
-  // No authors, title or year? Ignore.
-  if (!citation.authors || !citation.title || !citation.year) return [];
-
+  // Assume a default type of 'article' if none was provided.
   const type = citation.citation_type || 'article';
+
+  // In BibJSON, identifiers are kept separate from URLs.
   const identifiers = [];
   if (citation.doi) identifiers.push({ type: 'doi', id: citation.doi });
 
@@ -96,9 +101,9 @@ function convertCitation(citation) {
     section_title: (citation.section_title || '').trim(),
     year: (citation.year || '').trim(),
     edition: (citation.edition || '').trim(),
-    authors: convertAuthorsIntoObjects(citation.authors),
-    editors: convertAuthorsIntoObjects(citation.editors || []),
-    series_editors: convertAuthorsIntoObjects(citation.series_editors || []),
+    authors: convertAuthorsIntoBibJSON(citation.authors),
+    editors: convertAuthorsIntoBibJSON(citation.editors || []),
+    series_editors: convertAuthorsIntoBibJSON(citation.series_editors || []),
     publisher: (citation.publisher || '').trim(),
     city: (citation.city || '').trim(),
     pages: (citation.pages || '').trim(),
@@ -109,9 +114,12 @@ function convertCitation(citation) {
   });
 
   if (type === 'book' || type === 'book_section') {
-    // We already have all the details included, so don't add anything else.
+    // Add the ISBN to the entry itself.
+    if (citation.isbn) {
+      identifiers.push({ type: 'isbn', id: citation.isbn });
+    }
   } else if (type === 'journal') {
-    // Identifying journal identifiers.
+    // Identify journal identifiers, such as the
     const journalIdentifiers = [];
     if (citation.isbn) {
       journalIdentifiers.push({ type: 'isbn', id: citation.isbn });
@@ -129,8 +137,11 @@ function convertCitation(citation) {
       pages: (citation.pages || '').trim(),
       identifier: journalIdentifiers,
     });
+
+    // Since we've moved pages and ISBN into journal, we don't also need it in the main entry.
+    if (has(entry, 'pages')) delete entry.pages;
   } else {
-    throw new Error(`Unknown citation type: ${type}`);
+    process.stderr.write(`Unknown citation type: '${type}', using anyway.`);
   }
 
   return [entry];
@@ -160,6 +171,8 @@ let countErrors = 0;
 dump.forEach((entry) => {
   const phylorefLabel = entry.name.trim();
 
+  // Make sure we don't have multiple phyloreferences with the same label, since
+  // we name the file after the phyloreference being produced.
   if (has(phyxProduced, phylorefLabel)) {
     process.stderr.write(`Duplicate phyloreference label '${phylorefLabel}', skipping.`);
     countErrors += 1;
@@ -170,34 +183,44 @@ dump.forEach((entry) => {
   // we might be misinterpreting the input and should exit with an error.
   if (has(entry.citations, 'description')) {
     // The Regnum dumps contains citations marked "description" that are empty.
-    // Since convertCitation() removes citations that don't have a title and a
+    // Since convertCitationsToBibJSON() removes citations that don't have a title and a
     // year, we can use it to check whether the "description" citation(s) are
     // empty or contain an actual citation. In the latter case, we throw an Error
     // so we fail with an error.
-    const descriptionCitations = convertCitation(entry.citations.description);
+    const descriptionCitations = convertCitationsToBibJSON(entry.citations.description);
 
     if (descriptionCitations.length > 0) {
       throw new Error(`Citation of type 'description' found in entry: ${
-        JSON.stringify(convertCitation(entry.citations.definitional), null, 4)
+        JSON.stringify(convertCitationsToBibJSON(entry.citations.definitional), null, 4)
       }`);
     }
   }
 
-  // Prepare and fill a simple Phyx file template.
-  const phylorefTemplate = {
+  // Create an object describing this phyloreference.
+  const phylorefTemplate = pickBy({
     regnumId: entry.id,
     label: phylorefLabel,
     'dwc:scientificNameAuthorship': (convertAuthorsIntoStrings(entry.authors)).join(', '),
-    'dwc:namePublishedIn': convertCitation(entry.citations.preexisting),
+    'dwc:namePublishedIn': convertCitationsToBibJSON(entry.citations.preexisting),
     'obo:IAO_0000119': // IAO:definition source (http://purl.obolibrary.org/obo/IAO_0000119)
-      convertCitation(entry.citations.definitional),
-    primaryPhylogenyCitation: convertCitation(entry.citations.primary_phylogeny),
-    phylogenyCitation: convertCitation(entry.citations.phylogeny),
+      convertCitationsToBibJSON(entry.citations.definitional),
     cladeDefinition: (entry.definition || '').trim(),
     internalSpecifiers: [],
     externalSpecifiers: [],
-  };
+  });
 
+  // Do we have any phylogenies to save?
+  const primaryPhylogenyCitation = convertCitationsToBibJSON(entry.citations.primary_phylogeny).map(
+    phylogeny => pickBy({ primaryPhylogenyCitation: phylogeny })
+  );
+  const phylogenyCitation = convertCitationsToBibJSON(entry.citations.phylogeny).map(
+    phylogeny => pickBy({ primaryPhylogenyCitation: phylogeny })
+  );
+  const phylogenies = primaryPhylogenyCitation.concat(phylogenyCitation).filter(
+    phylogeny => !isEmpty(phylogeny)
+  );
+
+  // Convert each specifier into one
   (entry.specifiers || []).forEach((specifier) => {
     const kind = specifier.specifier_kind || '';
     let addTo = [];
@@ -208,14 +231,16 @@ dump.forEach((entry) => {
       countErrors += 1;
     }
 
+    // Set up specifier name, authorship and nomenclatural code.
     const specifierName = (specifier.specifier_name || '').trim();
     const specifierAuthors = (specifier.displayAuths || '').trim();
-    const specifierAuthority = (specifierAuthors.length > 0) ?
-      `${specifierAuthors}, ${(specifier.specifier_year || '').trim()}` :
-      (specifier.specifier_year || '').trim();
     const specifierCode = (specifier.specifier_code || '').trim();
 
-    // TODO: parse out genus and binomial name?
+    // Do we have authors? If so, incorporate them into the specifier authors.
+    // Otherwise, just use the year.
+    const specifierAuthority = (specifierAuthors.length > 0)
+      ? `${specifierAuthors}, ${(specifier.specifier_year || '').trim()}`
+      : (specifier.specifier_year || '').trim();
 
     const scname = `${specifierName} ${specifierAuthority}`.trim();
     const specifierTemplate = {
@@ -229,12 +254,12 @@ dump.forEach((entry) => {
   });
 
   // Prepare a simple Phyx file template.
-  const phyxTemplate = {
+  const phyxTemplate = pickBy({
     '@context': 'http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json',
-    phylogenies: [],
+    phylogenies,
     phylorefs: [phylorefTemplate],
     debug: entry, // To help with debugging, dump the entire entry into the Phyx file.
-  };
+  });
 
   // Write out Phyx file.
   const phyxFilename = path.join(argv.outputDir, `${phylorefLabel}.json`);
@@ -244,6 +269,7 @@ dump.forEach((entry) => {
   phyxProduced[phylorefLabel] = entry;
 });
 
+// If there were any errors, report this and exit with a failure code.
 if (countErrors > 0) {
   process.stderr.write(`${countErrors} errors occurred while processing database dump.\n`);
   process.exit(1);

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -139,7 +139,6 @@ function convertCitationsToBibJSON(citation) {
       name: (citation.journal || '').trim(),
       volume: (citation.volume || '').trim(),
       number: (citation.number || '').trim(),
-      pages: (citation.pages || '').trim(),
       identifier: journalIdentifiers,
     });
 

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -12,6 +12,18 @@ const path = require('path');
 const yargs = require('yargs');
 const { has, keys } = require('lodash');
 
+// Helper functions.
+function convertAuthorsIntoStrings(authors) {
+  // We combine authors as $first_name $middle_name $last_name.
+  // We could instead use foaf:firstName and foaf:lastName, but that's probably
+  // unnecessary (http://xmlns.com/foaf/spec/#term_firstName).
+  return authors.map(author => (
+    `${author.first_name || ''} ${
+      ((has(author, 'middle_name') && author.middle_name.trim() !== '') ? `${author.middle_name} ` : '')
+    }${author.last_name || ''}`
+  ).trim()).filter(name => name !== '');
+}
+
 // Read command-line arguments.
 const argv = yargs
   .usage('Usage: $0 <JSON file to process> -o <directory to write files to>')
@@ -44,7 +56,9 @@ dump.forEach((entry) => {
 
   // Prepare and fill a simple Phyx file template.
   const phylorefTemplate = {
+    regnumId: entry.id,
     label: phylorefLabel,
+    'dwc:scientificNameAuthorship': (convertAuthorsIntoStrings(entry.authors || []) || []).join(', '),
     cladeDefinition: (entry.definition || '').trim(),
     internalSpecifiers: [],
     externalSpecifiers: [],

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -222,7 +222,7 @@ dump.forEach((entry) => {
     phylogeny => pickBy({ primaryPhylogenyCitation: phylogeny })
   );
   const phylogenyCitation = convertCitationsToBibJSON(entry.citations.phylogeny).map(
-    phylogeny => pickBy({ primaryPhylogenyCitation: phylogeny })
+    phylogeny => pickBy({ phylogenyCitation: phylogeny })
   );
   const phylogenies = primaryPhylogenyCitation.concat(phylogenyCitation).filter(
     phylogeny => !isEmpty(phylogeny)

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -60,7 +60,11 @@ dump.forEach((entry) => {
       countErrors += 1;
     }
 
-    const scname = `${specifier.specifier_name || ''} ${specifier.displayAuths || ''}, ${specifier.specifier_year || ''} [${specifier.specifier_code || ''}]`;
+    const specifierName = (specifier.specifier_name || '').trim();
+    const specifierAuthority = `${(specifier.displayAuths || '').trim()}, ${(specifier.specifier_year || '').trim()}`;
+    const specifierCode = `[${(specifier.specifier_code || '').trim()}]`;
+
+    const scname = `${specifierName} ${specifierAuthority} ${specifierCode}`.trim();
     const specifierTemplate = {
       verbatimSpecifier: scname,
       referencesTaxonomicUnits: [{

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -113,7 +113,7 @@ function convertCitationsToBibJSON(citation) {
     city: (citation.city || '').trim(),
     pages: (citation.pages || '').trim(),
     figure: (citation.figure || '').trim(),
-    keywords: (citation.keyword || '').trim(),
+    // keywords: (citation.keyword || '').trim(), -- We really don't need this.
     identifier: identifiers,
     link: urls,
   });

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -31,7 +31,7 @@ function convertAuthorsIntoStrings(authors, lastNameFirst = true) {
   if (lastNameFirst) {
     // Use "last first middle".
     return authors.map(author => (
-      `${author.last_name || ''} ${author.first_name || ''}${
+      `${author.last_name || ''}, ${author.first_name || ''}${
         ((has(author, 'middle_name') && author.middle_name.trim() !== '') ? ` ${author.middle_name}` : '')
       }`.trim()
     )).filter(name => name !== '');
@@ -52,11 +52,11 @@ function convertAuthorsIntoBibJSON(authors) {
   return authors
     .filter(author => author.last_name)
     .map(author => pickBy({ // lodash.pickBy will remove empty keys from the object.
-      // We store the author name as last_name, first_name middle_name
-      name: convertAuthorsIntoStrings([author], true).join(),
+      // We store the author name as first_name middle_name last_name
+      name: convertAuthorsIntoStrings([author], false).join(),
       alternate: [
-        // We store an alternate author name as first_name middle_name last_name.
-        convertAuthorsIntoStrings([author], false).join(),
+        // We store an alternate author name as last_name, first_name middle_name.
+        convertAuthorsIntoStrings([author], true).join(),
       ],
       firstname: (author.first_name || '').trim(),
       lastname: (author.last_name || '').trim(),

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -159,17 +159,20 @@ dump.forEach((entry) => {
     }
 
     const specifierName = (specifier.specifier_name || '').trim();
-    const specifierAuthority = `${(specifier.displayAuths || '').trim()}, ${(specifier.specifier_year || '').trim()}`;
-    const specifierCode = `[${(specifier.specifier_code || '').trim()}]`;
+    const specifierAuthors = (specifier.displayAuths || '').trim();
+    const specifierAuthority = (specifierAuthors.length > 0) ?
+      `${specifierAuthors}, ${(specifier.specifier_year || '').trim()}` :
+      (specifier.specifier_year || '').trim();
+    const specifierCode = (specifier.specifier_code || '').trim();
 
-    const scname = `${specifierName} ${specifierAuthority} ${specifierCode}`.trim();
+    // TODO: parse out genus and binomial name?
+
+    const scname = `${specifierName} ${specifierAuthority}`.trim();
     const specifierTemplate = {
       verbatimSpecifier: scname,
-      referencesTaxonomicUnits: [{
-        scientificNames: [{
-          scientificName: scname,
-        }],
-      }],
+      scientificName: scname,
+      canonicalName: specifierName,
+      nomenclaturalCode: specifierCode,
     };
 
     addTo.push(specifierTemplate);

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -1,0 +1,97 @@
+/*
+ * regnum2phyx.js: A tool for converting PhyloRegnum database dumps to Phyx files.
+ *
+ * Synopsis: regnum2phyx.js [JSON file to process] -o [directory to write files to]
+ *
+ * PhyloRegnum can be accessed at http://app.phyloregnum.org
+ */
+
+// Load necessary modules.
+const fs = require('fs');
+const path = require('path');
+const yargs = require('yargs');
+const { has, keys } = require('lodash');
+
+// Read command-line arguments.
+const argv = yargs
+  .usage('Usage: $0 <JSON file to process> -o <directory to write files to>')
+  .demandCommand(1, 1) // Make sure there's one and only one file to convert.
+  .option('output-dir', {
+    alias: 'o',
+    describe: 'Directory to write Phyx files to',
+  })
+  .demandOption(['o'])
+  .help('h')
+  .alias('h', 'help')
+  .argv;
+
+// Read the database dump.
+const dump = JSON.parse(fs.readFileSync(argv._[0], 'utf8'));
+
+// This dump consists of multiple named phyloreferences, each of which should be
+// written out to a separate file.
+const phyxProduced = {};
+let countErrors = 0;
+
+dump.forEach((entry) => {
+  const phylorefLabel = entry.name.trim();
+
+  if (has(phyxProduced, phylorefLabel)) {
+    process.stderr.write(`Duplicate phyloreference label '${phylorefLabel}', skipping.`);
+    countErrors += 1;
+    return;
+  }
+
+  // Prepare and fill a simple Phyx file template.
+  const phylorefTemplate = {
+    label: phylorefLabel,
+    cladeDefinition: (entry.definition || '').trim(),
+    internalSpecifiers: [],
+    externalSpecifiers: [],
+  };
+
+  (entry.specifiers || []).forEach((specifier) => {
+    const kind = specifier.specifier_kind || '';
+    let addTo = [];
+    if (kind.startsWith('internal')) addTo = phylorefTemplate.internalSpecifiers;
+    else if (kind.startsWith('external')) addTo = phylorefTemplate.externalSpecifiers;
+    else {
+      process.stderr.write(`Unknown specifier type: '${kind}' for phyloreference '${phylorefLabel}'.\n`);
+      countErrors += 1;
+    }
+
+    const scname = `${specifier.specifier_name || ''} ${specifier.displayAuths || ''}, ${specifier.specifier_year || ''} [${specifier.specifier_code || ''}]`;
+    const specifierTemplate = {
+      verbatimSpecifier: scname,
+      referencesTaxonomicUnits: [{
+        scientificNames: [{
+          scientificName: scname,
+        }],
+      }],
+    };
+
+    addTo.push(specifierTemplate);
+  });
+
+  // Prepare a simple Phyx file template.
+  const phyxTemplate = {
+    '@context': 'http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json',
+    phylogenies: [],
+    phylorefs: [phylorefTemplate],
+    debug: entry, // To help with debugging, dump the entire entry into the Phyx file.
+  };
+
+  // Write out Phyx file.
+  const phyxFilename = path.join(argv.outputDir, `${phylorefLabel}.json`);
+  fs.writeFileSync(phyxFilename, JSON.stringify(phyxTemplate, null, 4));
+
+  // Save for later use if needed.
+  phyxProduced[phylorefLabel] = entry;
+});
+
+if (countErrors > 0) {
+  process.stderr.write(`${countErrors} errors occurred while processing database dump.\n`);
+  process.exit(1);
+} else {
+  process.stdout.write(`${keys(phyxProduced).length} Phyx files produced successfully.\n`);
+}

--- a/regnum2phyx/regnum2phyx.js
+++ b/regnum2phyx/regnum2phyx.js
@@ -49,6 +49,7 @@ function convertAuthorsIntoObjects(authors) {
       ],
       firstname: author.first_name || '',
       lastname: author.last_name || '',
+      middlename: author.middle_name || '',
     }));
 }
 

--- a/regnum2phyx/tests/examples/Crocodylia.regnum.json
+++ b/regnum2phyx/tests/examples/Crocodylia.regnum.json
@@ -1,0 +1,179 @@
+{
+    "id": 1,
+    "name": "Crocodylia",
+    "name_string": "Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.",
+    "submitted_by": 17,
+    "updated_at": null,
+    "submitted_at": null,
+    "submitted": null,
+    "establish": true,
+    "updated_by": null,
+    "status_id": 1,
+    "guid": null,
+    "qualifying_clause": null,
+    "authors": [
+        {
+            "first_name": "Christopher",
+            "middle_name": "A.",
+            "last_name": "Brochu"
+        }
+    ],
+    "comments": null,
+    "preexisting": true,
+    "preexisting_code": "ICZN",
+    "preexisting_authors": null,
+    "clade_type": "minimum-clade_standard",
+    "definition": "Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents",
+    "abbreviation": "Gavialis gangeticus & Alligator mississippiensis & Crocodylus niloticus",
+    "specifiers": [
+        {
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "Johann",
+                    "middle_name": "Friedrich",
+                    "last_name": "Gmelin"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Gavialis gangeticus",
+            "specifier_year": "1789",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Gmelin"
+        },
+        {
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "François",
+                    "middle_name": "Marie",
+                    "last_name": "Daudin"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Alligator mississippiensis",
+            "specifier_year": "1802",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Daudin"
+        },
+        {
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "Josephus",
+                    "middle_name": "Nicolaus",
+                    "last_name": "Laurenti"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Crocodylus niloticus",
+            "specifier_year": "1768",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Gmelin"
+        }
+    ],
+    "citations": {
+        "phylogeny": [
+            {
+                "citation_type": "journal",
+                "authors": [
+                    {
+                        "first_name": "Christopher",
+                        "middle_name": "A.",
+                        "last_name": "Brochu"
+                    }
+                ],
+                "editors": [],
+                "series_editors": [],
+                "title": "Phylogenetic approaches toward crocodylian history",
+                "section_title": "",
+                "publisher": "",
+                "figure": "1",
+                "year": "2003",
+                "edition": "",
+                "number": "",
+                "journal": "Annual Review of Earth and Planetary Sciences",
+                "city": "",
+                "volume": "31",
+                "pages": "357-397",
+                "keywords": "",
+                "isbn": "",
+                "doi": "10.1146/annurev.earth.31.100901.141308",
+                "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
+            }
+        ],
+        "description": {
+            "citation_type": "journal",
+            "authors": [
+                {
+                    "first_name": "Christopher",
+                    "middle_name": "A.",
+                    "last_name": "Brochu"
+                }
+            ],
+            "editors": [],
+            "series_editors": [],
+            "title": "Phylogenetic approaches toward crocodylian history",
+            "section_title": "",
+            "publisher": "",
+            "figure": "1",
+            "year": "2003",
+            "edition": "",
+            "number": "",
+            "journal": "Annual Review of Earth and Planetary Sciences",
+            "city": "",
+            "volume": "31",
+            "pages": "357-397",
+            "keywords": "",
+            "isbn": "",
+            "doi": "10.1146/annurev.earth.31.100901.141308",
+            "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
+        },
+        "preexisting": {
+            "citation_type": "book",
+            "authors": [
+                {
+                    "first_name": "Johann",
+                    "middle_name": "Friedrich",
+                    "last_name": "Gmelin"
+                }
+            ],
+            "editors": [],
+            "series_editors": [],
+            "title": "Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.",
+            "section_title": "",
+            "publisher": "Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.",
+            "figure": "",
+            "year": "1788",
+            "edition": "13",
+            "number": "",
+            "journal": "",
+            "city": "Lipsiae",
+            "volume": "",
+            "pages": "1057",
+            "keywords": "",
+            "isbn": "",
+            "doi": "10.5962/bhl.title.36932",
+            "url": "http://doi.org/10.5962/bhl.title.36932"
+        }
+    }
+}
+

--- a/test/regnum2phyx/examples/Crocodylia.json
+++ b/test/regnum2phyx/examples/Crocodylia.json
@@ -1,4 +1,4 @@
-{
+[{
     "id": 1,
     "name": "Crocodylia",
     "name_string": "Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.",
@@ -120,33 +120,6 @@
                 "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
             }
         ],
-        "description": {
-            "citation_type": "journal",
-            "authors": [
-                {
-                    "first_name": "Christopher",
-                    "middle_name": "A.",
-                    "last_name": "Brochu"
-                }
-            ],
-            "editors": [],
-            "series_editors": [],
-            "title": "Phylogenetic approaches toward crocodylian history",
-            "section_title": "",
-            "publisher": "",
-            "figure": "1",
-            "year": "2003",
-            "edition": "",
-            "number": "",
-            "journal": "Annual Review of Earth and Planetary Sciences",
-            "city": "",
-            "volume": "31",
-            "pages": "357-397",
-            "keywords": "",
-            "isbn": "",
-            "doi": "10.1146/annurev.earth.31.100901.141308",
-            "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
-        },
         "preexisting": {
             "citation_type": "book",
             "authors": [
@@ -175,5 +148,4 @@
             "url": "http://doi.org/10.5962/bhl.title.36932"
         }
     }
-}
-
+}]

--- a/test/regnum2phyx/examples/Crocodylia.json
+++ b/test/regnum2phyx/examples/Crocodylia.json
@@ -1,151 +1,151 @@
 [{
-  id: 1,
-  name: 'Crocodylia',
-  name_string: 'Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.',
-  submitted_by: 17,
-  updated_at: null,
-  submitted_at: null,
-  submitted: null,
-  establish: true,
-  updated_by: null,
-  status_id: 1,
-  guid: null,
-  qualifying_clause: null,
-  authors: [
-    {
-      first_name: 'Christopher',
-      middle_name: 'A.',
-      last_name: 'Brochu',
-    },
-  ],
-  comments: null,
-  preexisting: true,
-  preexisting_code: 'ICZN',
-  preexisting_authors: null,
-  clade_type: 'minimum-clade_standard',
-  definition: 'Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents',
-  abbreviation: 'Gavialis gangeticus & Alligator mississippiensis & Crocodylus niloticus',
-  specifiers: [
-    {
-      specifier_type: 'species',
-      authors: [
+    "id": 1,
+    "name": "Crocodylia",
+    "name_string": "Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.",
+    "submitted_by": 17,
+    "updated_at": null,
+    "submitted_at": null,
+    "submitted": null,
+    "establish": true,
+    "updated_by": null,
+    "status_id": 1,
+    "guid": null,
+    "qualifying_clause": null,
+    "authors": [
         {
-          first_name: 'Johann',
-          middle_name: 'Friedrich',
-          last_name: 'Gmelin',
-        },
-      ],
-      specifier_kind: 'internal extant',
-      specifier_character_name: '',
-      specifier_name: 'Gavialis gangeticus',
-      specifier_year: '1789',
-      specifier_code: 'ICZN',
-      collection_number: '',
-      collectors: [],
-      ubio_id: '',
-      ncbi_id: '',
-      treebase_id: '',
-      displayAuths: 'Gmelin',
-    },
-    {
-      specifier_type: 'species',
-      authors: [
-        {
-          first_name: 'François',
-          middle_name: 'Marie',
-          last_name: 'Daudin',
-        },
-      ],
-      specifier_kind: 'internal extant',
-      specifier_character_name: '',
-      specifier_name: 'Alligator mississippiensis',
-      specifier_year: '1802',
-      specifier_code: 'ICZN',
-      collection_number: '',
-      collectors: [],
-      ubio_id: '',
-      ncbi_id: '',
-      treebase_id: '',
-      displayAuths: 'Daudin',
-    },
-    {
-      specifier_type: 'species',
-      authors: [
-        {
-          first_name: 'Josephus',
-          middle_name: 'Nicolaus',
-          last_name: 'Laurenti',
-        },
-      ],
-      specifier_kind: 'internal extant',
-      specifier_character_name: '',
-      specifier_name: 'Crocodylus niloticus',
-      specifier_year: '1768',
-      specifier_code: 'ICZN',
-      collection_number: '',
-      collectors: [],
-      ubio_id: '',
-      ncbi_id: '',
-      treebase_id: '',
-      displayAuths: 'Gmelin',
-    },
-  ],
-  citations: {
-    phylogeny: [
-      {
-        citation_type: 'journal',
-        authors: [
-          {
-            first_name: 'Christopher',
-            middle_name: 'A.',
-            last_name: 'Brochu',
-          },
-        ],
-        editors: [],
-        series_editors: [],
-        title: 'Phylogenetic approaches toward crocodylian history',
-        section_title: '',
-        publisher: '',
-        figure: '1',
-        year: '2003',
-        edition: '',
-        number: '',
-        journal: 'Annual Review of Earth and Planetary Sciences',
-        city: '',
-        volume: '31',
-        pages: '357-397',
-        keywords: '',
-        isbn: '',
-        doi: '10.1146/annurev.earth.31.100901.141308',
-        url: 'https://doi.org/10.1146/annurev.earth.31.100901.141308',
-      },
+            "first_name": "Christopher",
+            "middle_name": "A.",
+            "last_name": "Brochu"
+        }
     ],
-    preexisting: {
-      citation_type: 'book',
-      authors: [
+    "comments": null,
+    "preexisting": true,
+    "preexisting_code": "ICZN",
+    "preexisting_authors": null,
+    "clade_type": "minimum-clade_standard",
+    "definition": "Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents",
+    "abbreviation": "Gavialis gangeticus & Alligator mississippiensis & Crocodylus niloticus",
+    "specifiers": [
         {
-          first_name: 'Johann',
-          middle_name: 'Friedrich',
-          last_name: 'Gmelin',
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "Johann",
+                    "middle_name": "Friedrich",
+                    "last_name": "Gmelin"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Gavialis gangeticus",
+            "specifier_year": "1789",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Gmelin"
         },
-      ],
-      editors: [],
-      series_editors: [],
-      title: 'Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.',
-      section_title: '',
-      publisher: 'Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.',
-      figure: '',
-      year: '1788',
-      edition: '13',
-      number: '',
-      journal: '',
-      city: 'Lipsiae',
-      volume: '',
-      pages: '1057',
-      keywords: '',
-      isbn: '',
-      doi: '10.5962/bhl.title.36932',
-      url: 'http://doi.org/10.5962/bhl.title.36932',
-    },
-  },
-}];
+        {
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "François",
+                    "middle_name": "Marie",
+                    "last_name": "Daudin"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Alligator mississippiensis",
+            "specifier_year": "1802",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Daudin"
+        },
+        {
+            "specifier_type": "species",
+            "authors": [
+                {
+                    "first_name": "Josephus",
+                    "middle_name": "Nicolaus",
+                    "last_name": "Laurenti"
+                }
+            ],
+            "specifier_kind": "internal extant",
+            "specifier_character_name": "",
+            "specifier_name": "Crocodylus niloticus",
+            "specifier_year": "1768",
+            "specifier_code": "ICZN",
+            "collection_number": "",
+            "collectors": [],
+            "ubio_id": "",
+            "ncbi_id": "",
+            "treebase_id": "",
+            "displayAuths": "Gmelin"
+        }
+    ],
+    "citations": {
+        "phylogeny": [
+            {
+                "citation_type": "journal",
+                "authors": [
+                    {
+                        "first_name": "Christopher",
+                        "middle_name": "A.",
+                        "last_name": "Brochu"
+                    }
+                ],
+                "editors": [],
+                "series_editors": [],
+                "title": "Phylogenetic approaches toward crocodylian history",
+                "section_title": "",
+                "publisher": "",
+                "figure": "1",
+                "year": "2003",
+                "edition": "",
+                "number": "",
+                "journal": "Annual Review of Earth and Planetary Sciences",
+                "city": "",
+                "volume": "31",
+                "pages": "357-397",
+                "keywords": "",
+                "isbn": "",
+                "doi": "10.1146/annurev.earth.31.100901.141308",
+                "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
+            }
+        ],
+        "preexisting": {
+            "citation_type": "book",
+            "authors": [
+                {
+                    "first_name": "Johann",
+                    "middle_name": "Friedrich",
+                    "last_name": "Gmelin"
+                }
+            ],
+            "editors": [],
+            "series_editors": [],
+            "title": "Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.",
+            "section_title": "",
+            "publisher": "Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.",
+            "figure": "",
+            "year": "1788",
+            "edition": "13",
+            "number": "",
+            "journal": "",
+            "city": "Lipsiae",
+            "volume": "",
+            "pages": "1057",
+            "keywords": "",
+            "isbn": "",
+            "doi": "10.5962/bhl.title.36932",
+            "url": "http://doi.org/10.5962/bhl.title.36932"
+        }
+    }
+}]

--- a/test/regnum2phyx/examples/Crocodylia.json
+++ b/test/regnum2phyx/examples/Crocodylia.json
@@ -1,151 +1,151 @@
 [{
-    "id": 1,
-    "name": "Crocodylia",
-    "name_string": "Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.",
-    "submitted_by": 17,
-    "updated_at": null,
-    "submitted_at": null,
-    "submitted": null,
-    "establish": true,
-    "updated_by": null,
-    "status_id": 1,
-    "guid": null,
-    "qualifying_clause": null,
-    "authors": [
+  id: 1,
+  name: 'Crocodylia',
+  name_string: 'Crocodylia (Gmelin, 1789) [Brochu 2003], converted clade name.',
+  submitted_by: 17,
+  updated_at: null,
+  submitted_at: null,
+  submitted: null,
+  establish: true,
+  updated_by: null,
+  status_id: 1,
+  guid: null,
+  qualifying_clause: null,
+  authors: [
+    {
+      first_name: 'Christopher',
+      middle_name: 'A.',
+      last_name: 'Brochu',
+    },
+  ],
+  comments: null,
+  preexisting: true,
+  preexisting_code: 'ICZN',
+  preexisting_authors: null,
+  clade_type: 'minimum-clade_standard',
+  definition: 'Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents',
+  abbreviation: 'Gavialis gangeticus & Alligator mississippiensis & Crocodylus niloticus',
+  specifiers: [
+    {
+      specifier_type: 'species',
+      authors: [
         {
-            "first_name": "Christopher",
-            "middle_name": "A.",
-            "last_name": "Brochu"
-        }
-    ],
-    "comments": null,
-    "preexisting": true,
-    "preexisting_code": "ICZN",
-    "preexisting_authors": null,
-    "clade_type": "minimum-clade_standard",
-    "definition": "Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents",
-    "abbreviation": "Gavialis gangeticus & Alligator mississippiensis & Crocodylus niloticus",
-    "specifiers": [
-        {
-            "specifier_type": "species",
-            "authors": [
-                {
-                    "first_name": "Johann",
-                    "middle_name": "Friedrich",
-                    "last_name": "Gmelin"
-                }
-            ],
-            "specifier_kind": "internal extant",
-            "specifier_character_name": "",
-            "specifier_name": "Gavialis gangeticus",
-            "specifier_year": "1789",
-            "specifier_code": "ICZN",
-            "collection_number": "",
-            "collectors": [],
-            "ubio_id": "",
-            "ncbi_id": "",
-            "treebase_id": "",
-            "displayAuths": "Gmelin"
+          first_name: 'Johann',
+          middle_name: 'Friedrich',
+          last_name: 'Gmelin',
         },
+      ],
+      specifier_kind: 'internal extant',
+      specifier_character_name: '',
+      specifier_name: 'Gavialis gangeticus',
+      specifier_year: '1789',
+      specifier_code: 'ICZN',
+      collection_number: '',
+      collectors: [],
+      ubio_id: '',
+      ncbi_id: '',
+      treebase_id: '',
+      displayAuths: 'Gmelin',
+    },
+    {
+      specifier_type: 'species',
+      authors: [
         {
-            "specifier_type": "species",
-            "authors": [
-                {
-                    "first_name": "François",
-                    "middle_name": "Marie",
-                    "last_name": "Daudin"
-                }
-            ],
-            "specifier_kind": "internal extant",
-            "specifier_character_name": "",
-            "specifier_name": "Alligator mississippiensis",
-            "specifier_year": "1802",
-            "specifier_code": "ICZN",
-            "collection_number": "",
-            "collectors": [],
-            "ubio_id": "",
-            "ncbi_id": "",
-            "treebase_id": "",
-            "displayAuths": "Daudin"
+          first_name: 'François',
+          middle_name: 'Marie',
+          last_name: 'Daudin',
         },
+      ],
+      specifier_kind: 'internal extant',
+      specifier_character_name: '',
+      specifier_name: 'Alligator mississippiensis',
+      specifier_year: '1802',
+      specifier_code: 'ICZN',
+      collection_number: '',
+      collectors: [],
+      ubio_id: '',
+      ncbi_id: '',
+      treebase_id: '',
+      displayAuths: 'Daudin',
+    },
+    {
+      specifier_type: 'species',
+      authors: [
         {
-            "specifier_type": "species",
-            "authors": [
-                {
-                    "first_name": "Josephus",
-                    "middle_name": "Nicolaus",
-                    "last_name": "Laurenti"
-                }
-            ],
-            "specifier_kind": "internal extant",
-            "specifier_character_name": "",
-            "specifier_name": "Crocodylus niloticus",
-            "specifier_year": "1768",
-            "specifier_code": "ICZN",
-            "collection_number": "",
-            "collectors": [],
-            "ubio_id": "",
-            "ncbi_id": "",
-            "treebase_id": "",
-            "displayAuths": "Gmelin"
-        }
-    ],
-    "citations": {
-        "phylogeny": [
-            {
-                "citation_type": "journal",
-                "authors": [
-                    {
-                        "first_name": "Christopher",
-                        "middle_name": "A.",
-                        "last_name": "Brochu"
-                    }
-                ],
-                "editors": [],
-                "series_editors": [],
-                "title": "Phylogenetic approaches toward crocodylian history",
-                "section_title": "",
-                "publisher": "",
-                "figure": "1",
-                "year": "2003",
-                "edition": "",
-                "number": "",
-                "journal": "Annual Review of Earth and Planetary Sciences",
-                "city": "",
-                "volume": "31",
-                "pages": "357-397",
-                "keywords": "",
-                "isbn": "",
-                "doi": "10.1146/annurev.earth.31.100901.141308",
-                "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
-            }
+          first_name: 'Josephus',
+          middle_name: 'Nicolaus',
+          last_name: 'Laurenti',
+        },
+      ],
+      specifier_kind: 'internal extant',
+      specifier_character_name: '',
+      specifier_name: 'Crocodylus niloticus',
+      specifier_year: '1768',
+      specifier_code: 'ICZN',
+      collection_number: '',
+      collectors: [],
+      ubio_id: '',
+      ncbi_id: '',
+      treebase_id: '',
+      displayAuths: 'Gmelin',
+    },
+  ],
+  citations: {
+    phylogeny: [
+      {
+        citation_type: 'journal',
+        authors: [
+          {
+            first_name: 'Christopher',
+            middle_name: 'A.',
+            last_name: 'Brochu',
+          },
         ],
-        "preexisting": {
-            "citation_type": "book",
-            "authors": [
-                {
-                    "first_name": "Johann",
-                    "middle_name": "Friedrich",
-                    "last_name": "Gmelin"
-                }
-            ],
-            "editors": [],
-            "series_editors": [],
-            "title": "Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.",
-            "section_title": "",
-            "publisher": "Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.",
-            "figure": "",
-            "year": "1788",
-            "edition": "13",
-            "number": "",
-            "journal": "",
-            "city": "Lipsiae",
-            "volume": "",
-            "pages": "1057",
-            "keywords": "",
-            "isbn": "",
-            "doi": "10.5962/bhl.title.36932",
-            "url": "http://doi.org/10.5962/bhl.title.36932"
-        }
-    }
-}]
+        editors: [],
+        series_editors: [],
+        title: 'Phylogenetic approaches toward crocodylian history',
+        section_title: '',
+        publisher: '',
+        figure: '1',
+        year: '2003',
+        edition: '',
+        number: '',
+        journal: 'Annual Review of Earth and Planetary Sciences',
+        city: '',
+        volume: '31',
+        pages: '357-397',
+        keywords: '',
+        isbn: '',
+        doi: '10.1146/annurev.earth.31.100901.141308',
+        url: 'https://doi.org/10.1146/annurev.earth.31.100901.141308',
+      },
+    ],
+    preexisting: {
+      citation_type: 'book',
+      authors: [
+        {
+          first_name: 'Johann',
+          middle_name: 'Friedrich',
+          last_name: 'Gmelin',
+        },
+      ],
+      editors: [],
+      series_editors: [],
+      title: 'Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.',
+      section_title: '',
+      publisher: 'Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.',
+      figure: '',
+      year: '1788',
+      edition: '13',
+      number: '',
+      journal: '',
+      city: 'Lipsiae',
+      volume: '',
+      pages: '1057',
+      keywords: '',
+      isbn: '',
+      doi: '10.5962/bhl.title.36932',
+      url: 'http://doi.org/10.5962/bhl.title.36932',
+    },
+  },
+}];

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -35,7 +35,7 @@ describe('Test PHYX files in repository', function () {
 
       // Run phyx2regnum.js on it.
       const child = ChildProcess.spawnSync(
-        '/usr/bin/node',
+        process.execPath,
         [
           'regnum2phyx/regnum2phyx.js',
           filepath,
@@ -44,7 +44,6 @@ describe('Test PHYX files in repository', function () {
         ],
         {
           encoding: 'utf8',
-          shell: true,
         }
       );
 

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -44,6 +44,7 @@ describe('Test PHYX files in repository', function () {
         ],
         {
           encoding: 'utf8',
+          shell: true,
         }
       );
 

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -5,11 +5,12 @@
 // Javascript libraries.
 const ChildProcess = require('child_process');
 const fs = require('fs');
-const path = require('path');
 
 const tmp = require('tmp');
 const chai = require('chai');
+const ajv = require('ajv');
 
+const assert = chai.assert;
 const expect = chai.expect;
 
 // Load a JSON file from the file system.
@@ -70,6 +71,18 @@ describe('Test PHYX files in repository', function () {
 
                 it('should be identical to expected', function () {
                     expect(producedPhyx).to.deep.equal(expectedPhyx);
+                });
+
+                const phyxSchemaJSON = loadJSON(`${__dirname}/phyx.schema.json`);
+                const ajvInstance = new ajv();
+                const phyxSchema = ajvInstance.compile(phyxSchemaJSON);
+                const result = phyxSchema(producedPhyx);
+                
+                it('should validate against the Phyx JSON Schema', function () {
+                    phyxSchema.errors.forEach(function (error) {
+                        assert.fail(ajvInstance.errorsText([error]));
+                    });
+                    expect(result).is.true;
                 });
             });
         });

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -35,7 +35,7 @@ describe('Test PHYX files in repository', function () {
 
       // Run phyx2regnum.js on it.
       const child = ChildProcess.spawnSync(
-        'node',
+        '/usr/bin/node',
         [
           'regnum2phyx/regnum2phyx.js',
           filepath,

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 
 const tmp = require('tmp');
 const chai = require('chai');
-const ajv = require('ajv');
+const Ajv = require('ajv');
 
 const assert = chai.assert;
 const expect = chai.expect;
@@ -74,10 +74,12 @@ describe('Test PHYX files in repository', function () {
                 });
 
                 const phyxSchemaJSON = loadJSON(`${__dirname}/phyx.schema.json`);
-                const ajvInstance = new ajv();
+                const ajvInstance = new Ajv({
+                  allErrors: true, // Display all error messages, not just the first.
+                });
                 const phyxSchema = ajvInstance.compile(phyxSchemaJSON);
                 const result = phyxSchema(producedPhyx);
-                
+
                 it('should validate against the Phyx JSON Schema', function () {
                     phyxSchema.errors.forEach(function (error) {
                         assert.fail(ajvInstance.errorsText([error]));

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -1,0 +1,78 @@
+/*
+ * exec.js: Tests execution of regnum2phyx.js.
+ */
+
+// Javascript libraries.
+const ChildProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const tmp = require('tmp');
+const chai = require('chai');
+
+const expect = chai.expect;
+
+// Load a JSON file from the file system.
+function loadJSON(filename) {
+    const content = fs.readFileSync(filename, { encoding: 'utf8' });
+    return JSON.parse(content);
+}
+
+describe('Test PHYX files in repository', function () {
+  fs.readdirSync(__dirname + '/examples').forEach(function (filename) {
+    describe(`Processing example Regnum dump: ${filename}`, function () {
+        const filepath = `${__dirname}/examples/${filename}`;
+
+        // We only test '.json' files.
+        if (!filepath.endsWith('.json')) {
+            it.skip('not a JSON file');
+            return;
+        }
+
+        // Create a temporary directory to make files into.
+        const tmpdirname = tmp.dirSync().name;
+
+        // Run phyx2regnum.js on it.
+        const child = ChildProcess.spawnSync(
+            'node',
+            [
+                'regnum2phyx/regnum2phyx.js',
+                filepath,
+                '-o',
+                tmpdirname
+            ],
+            {
+                encoding: 'utf8'
+            }
+        );
+
+        it('could be executed by regnum2phyx.js', function () {
+            expect(child.stderr).to.be.empty;
+            expect(child.stdout).to.match(/^(\d+) Phyx files produced successfully.\n$/);
+            expect(child.status).to.equal(0);
+        });
+
+        // There should be an ./expected/${basename} directory
+        // containing at least one file.
+        const basename = filename.replace(/.json$/i, '');
+        const producedFiles = fs.readdirSync(`${tmpdirname}`);
+        const expectedFiles = fs.readdirSync(`${__dirname}/expected/${basename}`);
+
+        it('should produce the expected files', function () {
+            expect(producedFiles).to.deep.equal(expectedFiles);
+            expect(producedFiles).to.not.be.empty;
+        });
+
+        producedFiles.forEach(function(producedFile) {
+            describe(`Testing produced file ${producedFile}`, function () {
+                const producedPhyx = loadJSON(`${tmpdirname}/${producedFile}`);
+                const expectedPhyx = loadJSON(`${__dirname}/expected/${basename}/${producedFile}`);
+
+                it('should be identical to expected', function () {
+                    expect(producedPhyx).to.deep.equal(expectedPhyx);
+                });
+            });
+        });
+    });
+  });
+});

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -81,7 +81,7 @@ describe('Test PHYX files in repository', function () {
           const result = phyxSchema(producedPhyx);
 
           it('should validate against the Phyx JSON Schema', function () {
-            phyxSchema.errors.forEach(function (error) {
+            (phyxSchema.errors || []).forEach(function (error) {
               assert.fail(ajvInstance.errorsText([error]));
             });
             expect(result).is.true;

--- a/test/regnum2phyx/exec.js
+++ b/test/regnum2phyx/exec.js
@@ -19,7 +19,7 @@ function loadJSON(filename) {
   return JSON.parse(content);
 }
 
-describe('Test PHYX files in repository', function () {
+describe('Test regnum2phyx.js', function () {
   fs.readdirSync(`${__dirname}/examples`).forEach(function (filename) {
     describe(`Processing example Regnum dump: ${filename}`, function () {
       const filepath = `${__dirname}/examples/${filename}`;

--- a/test/regnum2phyx/expected/Crocodylia/Crocodylia.json
+++ b/test/regnum2phyx/expected/Crocodylia/Crocodylia.json
@@ -5,7 +5,7 @@
             "phylogenyCitation": {
                 "type": "article",
                 "title": "Phylogenetic approaches toward crocodylian history",
-                "year": "2003",
+                "year": 2003,
                 "authors": [
                     {
                         "name": "Christopher A. Brochu",
@@ -48,7 +48,7 @@
                 {
                     "type": "book",
                     "title": "Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.",
-                    "year": "1788",
+                    "year": 1788,
                     "edition": "13",
                     "authors": [
                         {

--- a/test/regnum2phyx/expected/Crocodylia/Crocodylia.json
+++ b/test/regnum2phyx/expected/Crocodylia/Crocodylia.json
@@ -1,0 +1,107 @@
+{
+    "@context": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+    "phylogenies": [
+        {
+            "phylogenyCitation": {
+                "type": "article",
+                "title": "Phylogenetic approaches toward crocodylian history",
+                "year": "2003",
+                "authors": [
+                    {
+                        "name": "Christopher A. Brochu",
+                        "alternate": [
+                            "Brochu, Christopher A."
+                        ],
+                        "firstname": "Christopher",
+                        "lastname": "Brochu",
+                        "middlename": "A."
+                    }
+                ],
+                "editors": [],
+                "series_editors": [],
+                "figure": "1",
+                "identifier": [
+                    {
+                        "type": "doi",
+                        "id": "10.1146/annurev.earth.31.100901.141308"
+                    }
+                ],
+                "link": [
+                    {
+                        "url": "https://doi.org/10.1146/annurev.earth.31.100901.141308"
+                    }
+                ],
+                "journal": {
+                    "name": "Annual Review of Earth and Planetary Sciences",
+                    "volume": "31",
+                    "identifier": []
+                }
+            }
+        }
+    ],
+    "phylorefs": [
+        {
+            "regnumId": 1,
+            "label": "Crocodylia",
+            "dwc:scientificNameAuthorship": "Brochu, Christopher A.",
+            "dwc:namePublishedIn": [
+                {
+                    "type": "book",
+                    "title": "Caroli a Linné. Systema naturae per regna tria naturae : secundum classes, ordines, genera, species, cum characteribus, differentiis, synonymis, locis.",
+                    "year": "1788",
+                    "edition": "13",
+                    "authors": [
+                        {
+                            "name": "Johann Friedrich Gmelin",
+                            "alternate": [
+                                "Gmelin, Johann Friedrich"
+                            ],
+                            "firstname": "Johann",
+                            "lastname": "Gmelin",
+                            "middlename": "Friedrich"
+                        }
+                    ],
+                    "editors": [],
+                    "series_editors": [],
+                    "publisher": "Lipsiae :impensis Georg. Emanuel. Beer, 1788-93.",
+                    "city": "Lipsiae",
+                    "pages": "1057",
+                    "identifier": [
+                        {
+                            "type": "doi",
+                            "id": "10.5962/bhl.title.36932"
+                        }
+                    ],
+                    "link": [
+                        {
+                            "url": "http://doi.org/10.5962/bhl.title.36932"
+                        }
+                    ]
+                }
+            ],
+            "obo:IAO_0000119": [],
+            "cladeDefinition": "Last common ancestor of Gavialis gangeticus, Alligator mississippiensis, and Crocodylus niloticus and all of its descendents",
+            "internalSpecifiers": [
+                {
+                    "verbatimSpecifier": "Gavialis gangeticus Gmelin, 1789",
+                    "scientificName": "Gavialis gangeticus Gmelin, 1789",
+                    "canonicalName": "Gavialis gangeticus",
+                    "nomenclaturalCode": "ICZN"
+                },
+                {
+                    "verbatimSpecifier": "Alligator mississippiensis Daudin, 1802",
+                    "scientificName": "Alligator mississippiensis Daudin, 1802",
+                    "canonicalName": "Alligator mississippiensis",
+                    "nomenclaturalCode": "ICZN"
+                },
+                {
+                    "verbatimSpecifier": "Crocodylus niloticus Gmelin, 1768",
+                    "scientificName": "Crocodylus niloticus Gmelin, 1768",
+                    "canonicalName": "Crocodylus niloticus",
+                    "nomenclaturalCode": "ICZN"
+                }
+            ],
+            "externalSpecifiers": []
+        }
+    ]
+}

--- a/test/regnum2phyx/phyx.schema.json
+++ b/test/regnum2phyx/phyx.schema.json
@@ -18,6 +18,7 @@
     },
     "agent": {
       "$id": "#/definitions/agent",
+      "title": "An agent, such as an author, editor or series editor",
       "type": "object",
       "required": [
         "name"
@@ -57,6 +58,7 @@
     },
     "citation": {
       "$id": "#/definitions/citation",
+      "title": "A citation",
       "type": "object",
       "required": [
         "type",
@@ -161,18 +163,23 @@
     },
     "specifier": {
       "@id": "#/definitions/specifier",
+      "title": "A specifier",
       "type": "object",
       "properties": {
         "verbatimSpecifier": {
+          "title": "The verbatim description of this specifier",
           "type": "string"
         },
         "scientificName": {
+          "title": "The scientific name of this specifier",
           "type": "string"
         },
         "canonicalName": {
+          "title": "The canonical name of this specifier, i.e. the genus and specific epithet only",
           "type": "string"
         },
         "nomenclaturalCode": {
+          "title": "The nomenclatural code of this specifier",
           "enum": [ "ICZN", "ICBN", "ICNafp" ]
         }
       }
@@ -212,20 +219,26 @@
             ]
           },
           "primaryPhylogenyCitation": {
-            "$ref": "#/definitions/citation"
+            "title": "The primary phylogeny citation for the phyloreferences in this file",
+            "items": {
+              "$ref": "#/definitions/citation"
+            }
           },
           "phylogenyCitation": {
-            "$ref": "#/definitions/citation"
+            "title": "A phylogeny citation for the phyloreferences in this file",
+            "items": {
+              "$ref": "#/definitions/citation"
+            }
           }
         }
       }
     },
     "phylorefs": {
       "type": "array",
-      "title": "The Phylorefs Schema",
+      "title": "The phyloreferences in this Phyx file",
       "items": {
         "type": "object",
-        "title": "The Items Schema",
+        "title": "A phyloreference in this Phyx file",
         "required": [
           "label",
           "cladeDefinition",
@@ -235,14 +248,14 @@
         "properties": {
           "label": {
             "type": "string",
-            "title": "The Label Schema",
+            "title": "The label of this phyloreference",
             "examples": [
               "Eusuchia"
             ]
           },
           "cladeDefinition": {
             "type": "string",
-            "title": "The Cladedefinition Schema",
+            "title": "The verbatim clade definition of this phyloreference",
             "examples": [
               "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents."
             ]
@@ -263,10 +276,10 @@
           },
           "pso:holdsStatusInTime": {
             "type": "array",
-            "title": "The Pso:holdsstatusintime Schema",
+            "title": "List of publication statuses that have applied to this phyloreference at different times",
             "items": {
               "type": "object",
-              "title": "The Items Schema",
+              "title": "A particular status at a particular time",
               "required": [
                 "@type",
                 "pso:withStatus",
@@ -274,47 +287,50 @@
               ],
               "properties": {
                 "@type": {
-                  "type": "string",
-                  "title": "The @type Schema",
-                  "default": "",
-                  "examples": [
-                    "http://purl.org/spar/pso/StatusInTime"
-                  ],
-                  "pattern": "^(.*)$"
+                  "const": "http://purl.org/spar/pso/StatusInTime"
                 },
                 "pso:withStatus": {
                   "type": "object",
-                  "title": "The Pso:withstatus Schema",
+                  "title": "The status that applied to this phyloreference at this time.",
                   "required": [
                     "@id"
                   ],
                   "properties": {
                     "@id": {
-                      "type": "string",
-                      "title": "The @id Schema",
-                      "default": "",
-                      "examples": [
-                        "pso:final-draft"
-                      ],
-                      "pattern": "^(.*)$"
+                      "title": "The type of this status",
+                      "enum": [
+                        "pso:draft",
+                        "pso:final-draft",
+                        "pso:under-review",
+                        "pso:submitted",
+                        "pso:published",
+                        "pso:retracted-from-publication"
+                      ]
                     }
                   }
                 },
                 "tvc:atTime": {
                   "type": "object",
-                  "title": "The Tvc:attime Schema",
+                  "title": "The time at which this status applied to this phyloreference.",
                   "required": [
                     "timeinterval:hasIntervalStartDate"
                   ],
                   "properties": {
                     "timeinterval:hasIntervalStartDate": {
                       "type": "string",
-                      "title": "The Timeinterval:hasintervalstartdate Schema",
-                      "default": "",
+                      "format": "date-time",
+                      "title": "When did this phyloreference start being in this state",
                       "examples": [
                         "2018-06-11T22:46:23.547Z"
-                      ],
-                      "pattern": "^(.*)$"
+                      ]
+                    },
+                    "timeinterval:hasIntervalEndDate": {
+                      "type": "string",
+                      "format": "date-time",
+                      "title": "When did this phyloreference end being in this state",
+                      "examples": [
+                        "2018-06-11T22:46:23.547Z"
+                      ]
                     }
                   }
                 }

--- a/test/regnum2phyx/phyx.schema.json
+++ b/test/regnum2phyx/phyx.schema.json
@@ -260,6 +260,20 @@
               "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents."
             ]
           },
+          "dwc:namePublishedIn": {
+            "title": "A citation for the original description of the pre-existing name of this phyloreference",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/citation"
+            }
+          },
+          "obo:IAO_0000119": {
+            "title": "A citation for this phyloreference definition",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/citation"
+            }
+          },
           "internalSpecifiers": {
             "type": "array",
             "title": "Internal specifiers of this phyloreference",

--- a/test/regnum2phyx/phyx.schema.json
+++ b/test/regnum2phyx/phyx.schema.json
@@ -1,0 +1,378 @@
+{
+  "definitions": {
+    "identifier": {
+      "$id": "#/definitions/identifier",
+      "type": "object",
+      "title": "Identifier for a publication",
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "doi"
+          ]
+        }
+      }
+    },
+    "agent": {
+      "$id": "#/definitions/agent",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "title": "The name of this agent",
+          "examples": [
+            "Charles Darwin"
+          ]
+        },
+        "alternate": {
+          "title": "Alternate name for this agent",
+          "examples": [
+            "Darwin, Charles"
+          ]
+        },
+        "firstname": {
+          "title": "First name for this agent",
+          "examples": [
+            "Charles"
+          ]
+        },
+        "middlename": {
+          "title": "Middle name for this agent",
+          "examples": [
+            "Robert"
+          ]
+        },
+        "lastname": {
+          "title": "Last name for this agent",
+          "examples": [
+            "Charles"
+          ]
+        }
+      }
+    },
+    "citation": {
+      "$id": "#/definitions/citation",
+      "type": "object",
+      "required": [
+        "type",
+        "authors",
+        "title",
+        "year"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "article",
+            "book",
+            "book_section"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "year": {
+          "type": "integer",
+          "minimum": -9999,
+          "maximum": 9999
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/agent"
+          }
+        },
+        "editors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/agent"
+          }
+        },
+        "series_editors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/agent"
+          }
+        },
+        "figure": {
+          "type": "string",
+          "title": "Figure description"
+        },
+        "publisher": {
+          "type": "string",
+          "title": "The publisher of this publication"
+        },
+        "city": {
+          "type": "string",
+          "title": "The city in which this publication was published"
+        },
+        "pages": {
+          "type": "string",
+          "title": "The pages of this publication"
+        },
+        "identifier": {
+          "type": "array",
+          "title": "Identifiers for this publication",
+          "items": {
+            "$ref": "#/definitions/identifier"
+          }
+        },
+        "link": {
+          "type": "array",
+          "title": "URLs for this publication",
+          "items": {
+            "type": "object",
+            "required": [ "url" ],
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
+        },
+        "journal": {
+          "type": "object",
+          "title": "Information about the journal this publication is in.",
+          "required": [ "name" ],
+          "properties": {
+            "name": {
+              "title": "Title of the journal",
+              "type": "string"
+            },
+            "volume": {
+              "title": "Volume in this journal",
+              "type": "string"
+            },
+            "identifier": {
+              "type": "array",
+              "title": "Identifiers for this journal",
+              "items": {
+                "$ref": "#/definitions/identifier"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://phyloref.org/phyx.js/schema/v1.0.0/phyx.schema.json",
+  "type": "object",
+  "title": "Phyloreference Exchange (Phyx) schema",
+  "required": [
+    "@context",
+    "phylogenies",
+    "phylorefs"
+  ],
+  "properties": {
+    "@context": {
+      "$id": "#/properties/@context",
+      "type": "string",
+      "title": "JSON-LD schema for interpreting this Phyx file",
+      "default": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
+      "examples": [
+        "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json"
+      ]
+    },
+    "phylogenies": {
+      "type": "array",
+      "title": "Phylogenies in this Phyx file",
+      "items": {
+        "type": "object",
+        "title": "A single phylogeny in this Phyx file",
+        "properties": {
+          "newick": {
+            "type": "string",
+            "title": "This phylogeny in the Newick format (https://en.wikipedia.org/wiki/Newick_format)",
+            "examples": [
+              "((Homo, Pan)Hominini, Gorilla);"
+            ]
+          },
+          "primaryPhylogenyCitation": {
+            "$ref": "#/definitions/citation"
+          },
+          "phylogenyCitation": {
+            "$ref": "#/definitions/citation"
+          }
+        }
+      }
+    },
+    "phylorefs": {
+      "type": "array",
+      "title": "The Phylorefs Schema",
+      "items": {
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "label",
+          "cladeDefinition",
+          "internalSpecifiers",
+          "externalSpecifiers",
+          "pso:holdsStatusInTime"
+        ],
+        "properties": {
+          "label": {
+            "$id": "#/properties/phylorefs/items/properties/label",
+            "type": "string",
+            "title": "The Label Schema",
+            "default": "",
+            "examples": [
+              "Eusuchia"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "cladeDefinition": {
+            "$id": "#/properties/phylorefs/items/properties/cladeDefinition",
+            "type": "string",
+            "title": "The Cladedefinition Schema",
+            "default": "",
+            "examples": [
+              "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents."
+            ],
+            "pattern": "^(.*)$"
+          },
+          "internalSpecifiers": {
+            "$id": "#/properties/phylorefs/items/properties/internalSpecifiers",
+            "type": "array",
+            "title": "The Internalspecifiers Schema",
+            "items": {
+              "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items",
+              "type": "object",
+              "title": "The Items Schema",
+              "required": [
+                "referencesTaxonomicUnits"
+              ],
+              "properties": {
+                "referencesTaxonomicUnits": {
+                  "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits",
+                  "type": "array",
+                  "title": "The Referencestaxonomicunits Schema",
+                  "items": {
+                    "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items",
+                    "type": "object",
+                    "title": "The Items Schema",
+                    "required": [
+                      "scientificNames"
+                    ],
+                    "properties": {
+                      "scientificNames": {
+                        "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames",
+                        "type": "array",
+                        "title": "The Scientificnames Schema",
+                        "items": {
+                          "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames/items",
+                          "type": "object",
+                          "title": "The Items Schema",
+                          "required": [
+                            "scientificName"
+                          ],
+                          "properties": {
+                            "scientificName": {
+                              "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames/items/properties/scientificName",
+                              "type": "string",
+                              "title": "The Scientificname Schema",
+                              "default": "",
+                              "examples": [
+                                "Alligator mississippiensis"
+                              ],
+                              "pattern": "^(.*)$"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "externalSpecifiers": {
+            "$id": "#/properties/phylorefs/items/properties/externalSpecifiers",
+            "type": "array",
+            "title": "The Externalspecifiers Schema"
+          },
+          "pso:holdsStatusInTime": {
+            "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime",
+            "type": "array",
+            "title": "The Pso:holdsstatusintime Schema",
+            "items": {
+              "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items",
+              "type": "object",
+              "title": "The Items Schema",
+              "required": [
+                "@type",
+                "pso:withStatus",
+                "tvc:atTime"
+              ],
+              "properties": {
+                "@type": {
+                  "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items/properties/@type",
+                  "type": "string",
+                  "title": "The @type Schema",
+                  "default": "",
+                  "examples": [
+                    "http://purl.org/spar/pso/StatusInTime"
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "pso:withStatus": {
+                  "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items/properties/pso:withStatus",
+                  "type": "object",
+                  "title": "The Pso:withstatus Schema",
+                  "required": [
+                    "@id"
+                  ],
+                  "properties": {
+                    "@id": {
+                      "type": "string",
+                      "title": "The @id Schema",
+                      "default": "",
+                      "examples": [
+                        "pso:final-draft"
+                      ],
+                      "pattern": "^(.*)$"
+                    }
+                  }
+                },
+                "tvc:atTime": {
+                  "type": "object",
+                  "title": "The Tvc:attime Schema",
+                  "required": [
+                    "timeinterval:hasIntervalStartDate"
+                  ],
+                  "properties": {
+                    "timeinterval:hasIntervalStartDate": {
+                      "type": "string",
+                      "title": "The Timeinterval:hasintervalstartdate Schema",
+                      "default": "",
+                      "examples": [
+                        "2018-06-11T22:46:23.547Z"
+                      ],
+                      "pattern": "^(.*)$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "title": {
+      "$id": "#/properties/title",
+      "type": "string",
+      "title": "The Title Schema",
+      "default": "",
+      "examples": [
+        "Phylogenetic Approaches Toward Crocodylian History"
+      ],
+      "pattern": "^(.*)$"
+    }
+  }
+}

--- a/test/regnum2phyx/phyx.schema.json
+++ b/test/regnum2phyx/phyx.schema.json
@@ -158,6 +158,24 @@
           }
         }
       }
+    },
+    "specifier": {
+      "@id": "#/definitions/specifier",
+      "type": "object",
+      "properties": {
+        "verbatimSpecifier": {
+          "type": "string"
+        },
+        "scientificName": {
+          "type": "string"
+        },
+        "canonicalName": {
+          "type": "string"
+        },
+        "nomenclaturalCode": {
+          "enum": [ "ICZN", "ICBN", "ICNafp" ]
+        }
+      }
     }
   },
 
@@ -172,7 +190,6 @@
   ],
   "properties": {
     "@context": {
-      "$id": "#/properties/@context",
       "type": "string",
       "title": "JSON-LD schema for interpreting this Phyx file",
       "default": "http://www.phyloref.org/phyx.js/context/v0.1.0/phyx.json",
@@ -213,96 +230,41 @@
           "label",
           "cladeDefinition",
           "internalSpecifiers",
-          "externalSpecifiers",
-          "pso:holdsStatusInTime"
+          "externalSpecifiers"
         ],
         "properties": {
           "label": {
-            "$id": "#/properties/phylorefs/items/properties/label",
             "type": "string",
             "title": "The Label Schema",
-            "default": "",
             "examples": [
               "Eusuchia"
-            ],
-            "pattern": "^(.*)$"
+            ]
           },
           "cladeDefinition": {
-            "$id": "#/properties/phylorefs/items/properties/cladeDefinition",
             "type": "string",
             "title": "The Cladedefinition Schema",
-            "default": "",
             "examples": [
               "Eusuchia (Huxley 1875). Amended definition.\n\nLast common ancestor of Hylaeochampsa vectiana, Crocodylus niloticus, Gavialis gangeticus, and Alligator mississippiensis\t and all of its descendents."
-            ],
-            "pattern": "^(.*)$"
+            ]
           },
           "internalSpecifiers": {
-            "$id": "#/properties/phylorefs/items/properties/internalSpecifiers",
             "type": "array",
-            "title": "The Internalspecifiers Schema",
+            "title": "Internal specifiers of this phyloreference",
             "items": {
-              "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items",
-              "type": "object",
-              "title": "The Items Schema",
-              "required": [
-                "referencesTaxonomicUnits"
-              ],
-              "properties": {
-                "referencesTaxonomicUnits": {
-                  "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits",
-                  "type": "array",
-                  "title": "The Referencestaxonomicunits Schema",
-                  "items": {
-                    "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items",
-                    "type": "object",
-                    "title": "The Items Schema",
-                    "required": [
-                      "scientificNames"
-                    ],
-                    "properties": {
-                      "scientificNames": {
-                        "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames",
-                        "type": "array",
-                        "title": "The Scientificnames Schema",
-                        "items": {
-                          "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames/items",
-                          "type": "object",
-                          "title": "The Items Schema",
-                          "required": [
-                            "scientificName"
-                          ],
-                          "properties": {
-                            "scientificName": {
-                              "$id": "#/properties/phylorefs/items/properties/internalSpecifiers/items/properties/referencesTaxonomicUnits/items/properties/scientificNames/items/properties/scientificName",
-                              "type": "string",
-                              "title": "The Scientificname Schema",
-                              "default": "",
-                              "examples": [
-                                "Alligator mississippiensis"
-                              ],
-                              "pattern": "^(.*)$"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+              "$ref": "#/definitions/specifier"
             }
           },
           "externalSpecifiers": {
-            "$id": "#/properties/phylorefs/items/properties/externalSpecifiers",
             "type": "array",
-            "title": "The Externalspecifiers Schema"
+            "title": "External specifiers of this phyloreference",
+            "items": {
+              "$ref": "#/definitions/specifier"
+            }
           },
           "pso:holdsStatusInTime": {
-            "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime",
             "type": "array",
             "title": "The Pso:holdsstatusintime Schema",
             "items": {
-              "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items",
               "type": "object",
               "title": "The Items Schema",
               "required": [
@@ -312,7 +274,6 @@
               ],
               "properties": {
                 "@type": {
-                  "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items/properties/@type",
                   "type": "string",
                   "title": "The @type Schema",
                   "default": "",
@@ -322,7 +283,6 @@
                   "pattern": "^(.*)$"
                 },
                 "pso:withStatus": {
-                  "$id": "#/properties/phylorefs/items/properties/pso:holdsStatusInTime/items/properties/pso:withStatus",
                   "type": "object",
                   "title": "The Pso:withstatus Schema",
                   "required": [
@@ -363,16 +323,6 @@
           }
         }
       }
-    },
-    "title": {
-      "$id": "#/properties/title",
-      "type": "string",
-      "title": "The Title Schema",
-      "default": "",
-      "examples": [
-        "Phylogenetic Approaches Toward Crocodylian History"
-      ],
-      "pattern": "^(.*)$"
     }
   }
 }


### PR DESCRIPTION
This PR includes a command line regnum2phyx script that can convert Regnum database dumps into a directory of Phyx files. It also includes tests for the output of that script, by ensuring that (1) the JSON file produced is identical to the expected JSON file we've previous calculated, and (2) whether it can be validated against a first draft of a JSON schema for Phyx files.

Should be merged after RT #70, as otherwise the Travis CI tests fail in phyx2ontology.

The current conversion test is based on a single Regnum dump written by hand and based on the Crocodylia phyloreference from the Brochu 2003 test file. We should eventually expand this to a partial Regnum dump once parts of Regnum have become public.

Note that the JSON schema is a model 2.0 schema rather than a model 1.0 schema: the next step is to update the Curation Tool and phyx.js to model 2.0, at which point they will be able to use Phyx in those schemas.