### PR TITLE
Converted some `@type`s into `rdf:type` entries.

### DIFF
--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -14,7 +14,7 @@ const process = require('process');
 const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
-const { has } = require('lodash');
+const { has, isString } = require('lodash');
 
 // Load phyx.js, our PHYX library.
 const phyx = require('@phyloref/phyx');
@@ -247,6 +247,13 @@ jsons.forEach((phyxFile) => {
           });
         });
       }
+
+      // Now, rdfpipe can handle '@type's that contain restrictions,
+      // but OWLAPI can't. So let's translate all '@type's into
+      // 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'.
+      node['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'] = node['@type']
+        .map(c => isString(c) ? { '@id': c } : c);
+      delete node['@type'];
     });
 
     // Set a '@context' so it can be interpreted from other objects in the output file.


### PR DESCRIPTION
RDFpipe can handle '@type's containing entire OWL restrictions without any problem (e.g. `"@type": [{ "@type": "owl:Restriction", ... }]`). Doing this causes an error in the JSON-LD library we're using in JPhyloRef, which expects `@type` to be a string or an array of strings ([1](https://github.com/jsonld-java/jsonld-java/blob/0190cdbd252999b97a519e6a1bc0683c71d3ca1b/core/src/main/java/com/github/jsonldjava/core/JsonLdApi.java#L620-L621)).

The quick solution to this is to set `rdf:type` in the JSON-LD instead of `@type`, which seems to work with both RDFpipe (and subsequently Protege) as well as JPhyloRef.