### PR TITLE
Update documentation and AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore data files.
+/data/
+
 # Ignore files produced by the test suite
 paper_as_owl.json
 paper.owl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ The Clade Ontology is an ontology of exemplar phyloreferences curated from Phylo
 
 ```bash
 npm test           # Lint + run all Mocha tests (requires Node.js)
-npm run lint       # ESLint on test/, phyx2ontology/, and regnum2phyx/
+npm run lint       # Biome lint on test/, phyx2ontology/, and regnum2phyx/
 npm run mocha      # Run tests without linting
 npm run build-ontology  # Convert all phyx/ files into CLADO.json
 ```
@@ -82,7 +82,7 @@ PHYX files are JSON with:
 
 ### Linting
 
-ESLint uses `airbnb-base` + `mocha` plugin. Trailing commas required on multiline arrays/objects (not functions). ES6 syntax.
+Linting uses [Biome](https://biomejs.dev/). ES6 syntax.
 
 ### Git-Crypt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ PhyloRegnum DB dump (JSON)
 - **`data/`** — Git-ignored directory for raw PhyloRegnum database dumps (JSON files) used as input to `regnum2phyx.js`. Not committed.
 - **`phyx/`** — Curated PHYX files organized by source:
   - `from_papers/` — Phyloreferences from peer-reviewed papers (e.g., `Brochu 2003/`)
-  - `phylonym/` — Files from the PhyloNym database
+  - `phylonym/` — Files from the Phylonym database, PhyloRegnum (https://www.phyloregnum.org/)
   - `encrypted/` — Git-crypt encrypted files (skipped during processing)
 - **`phyx2ontology/phyx2ontology.js`** — Converts Phyx files to a single Clade Ontology JSON-LD. Reads Phyx files, wraps them via `@phyloref/phyx`, and emits JSON-LD to STDOUT.
 - **`regnum2phyx/regnum2phyx.js`** — Converts PhyloRegnum database dumps (JSON arrays) into individual PHYX files. Handles specifiers, citations (BibJSON format), and author formatting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ node regnum2phyx/regnum2phyx.js dump.json -o output_dir/ --filenames regnum-id
 
 ```
 PhyloRegnum DB dump (JSON)
-    → regnum2phyx.js → PHYX files (.json in phyx/)
+    → regnum2phyx.js → Phyx files (.json in phyx/)
     → phyx2ontology.js → CLADO.json (OWL/JSON-LD)
     → JPhyloRef (Java) → reasoning/test results
 ```
@@ -58,27 +58,27 @@ PhyloRegnum DB dump (JSON)
 ### Key Directories
 
 - **`data/`** — Git-ignored directory for raw PhyloRegnum database dumps (JSON files) used as input to `regnum2phyx.js`. Not committed.
-- **`phyx/`** — Curated PHYX files organized by source:
+- **`phyx/`** — Curated Phyx files organized by source:
   - `from_papers/` — Phyloreferences from peer-reviewed papers (e.g., `Brochu 2003/`)
   - `phylonym/` — Files from the Phylonym database, PhyloRegnum (https://www.phyloregnum.org/)
   - `encrypted/` — Git-crypt encrypted files (skipped during processing)
 - **`phyx2ontology/phyx2ontology.js`** — Converts Phyx files to a single Clade Ontology JSON-LD. Reads Phyx files, wraps them via `@phyloref/phyx`, and emits JSON-LD to STDOUT.
-- **`regnum2phyx/regnum2phyx.js`** — Converts PhyloRegnum database dumps (JSON arrays) into individual PHYX files. Handles specifiers, citations (BibJSON format), and author formatting.
+- **`regnum2phyx/regnum2phyx.js`** — Converts PhyloRegnum database dumps (JSON arrays) into individual Phyx files. Handles specifiers, citations (BibJSON format), and author formatting.
 - **`test/`** — Mocha test suite:
-  - `test_phyx.js` — Validates all PHYX files in `phyx/` (JSON schema + JSON-LD conversion). Skips git-crypt encrypted files.
+  - `test_phyx.js` — Validates all Phyx files in `phyx/` (JSON schema + JSON-LD conversion). Skips git-crypt encrypted files.
   - `test_phyx2ontology.js` — Smoke-tests `phyx2ontology.js` execution on all Phyx files.
   - `regnum2phyx/exec.js` — Tests `regnum2phyx.js` against example dumps in `test/regnum2phyx/examples/` and compares output against `test/regnum2phyx/expected/`.
 
-### PHYX Format
+### Phyx Format
 
-PHYX files are JSON with:
+Phyx files are JSON with:
 - `@context`: points to `http://www.phyloref.org/phyx.js/context/v1.1.0/phyx.json`
 - `phylorefs`: array of phyloreference objects with `internalSpecifiers`, `externalSpecifiers`, `definition`, etc.
 - `phylogenies`: array of phylogeny objects with Newick strings
 
 ### Key Library
 
-`@phyloref/phyx` (npm) provides `PhylorefWrapper`, `PhylogenyWrapper`, and `PhyxWrapper` classes that convert PHYX objects to JSON-LD/OWL class restrictions.
+`@phyloref/phyx` (npm) provides `PhylorefWrapper`, `PhylogenyWrapper`, and `PhyxWrapper` classes that convert Phyx objects to JSON-LD/OWL class restrictions.
 
 ### Linting
 
@@ -86,4 +86,4 @@ Linting uses [Biome](https://biomejs.dev/). ES6 syntax.
 
 ### Git-Crypt
 
-Some PHYX files in `phyx/encrypted/` are git-crypt encrypted. Both `phyx2ontology.js` and `test_phyx.js` detect these by checking for the `\x00GITCRYPT` magic bytes and skip them gracefully.
+Some Phyx files in `phyx/encrypted/` are git-crypt encrypted. Both `phyx2ontology.js` and `test_phyx.js` detect these by checking for the `\x00GITCRYPT` magic bytes and skip them gracefully.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ PhyloRegnum DB dump (JSON)
   - `from_papers/` — Phyloreferences from peer-reviewed papers (e.g., `Brochu 2003/`)
   - `phylonym/` — Files from the PhyloNym database
   - `encrypted/` — Git-crypt encrypted files (skipped during processing)
-- **`phyx2ontology/phyx2ontology.js`** — Converts PHYX files to a single Clade Ontology JSON-LD. Reads PHYX files, wraps them via `@phyloref/phyx`, and emits JSON-LD to STDOUT.
+- **`phyx2ontology/phyx2ontology.js`** — Converts Phyx files to a single Clade Ontology JSON-LD. Reads Phyx files, wraps them via `@phyloref/phyx`, and emits JSON-LD to STDOUT.
 - **`regnum2phyx/regnum2phyx.js`** — Converts PhyloRegnum database dumps (JSON arrays) into individual PHYX files. Handles specifiers, citations (BibJSON format), and author formatting.
 - **`test/`** — Mocha test suite:
   - `test_phyx.js` — Validates all PHYX files in `phyx/` (JSON schema + JSON-LD conversion). Skips git-crypt encrypted files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, Codex, etc.) when 
 
 ## Overview
 
-The Clade Ontology is an ontology of exemplar phyloreferences curated from peer-reviewed publications. It stores phyloreferences (computable clade definitions) as PHYX files that are converted to OWL/JSON-LD for reasoning with an OWL reasoner (JPhyloRef + JFact++).
+The Clade Ontology is an ontology of exemplar phyloreferences curated from PhyloRegnum (https://www.phyloregnum.org/) and peer-reviewed publications. It stores phyloreferences (computable clade definitions) as PHYX files that are converted to n-triples and OWL/JSON-LD for reasoning with an OWL reasoner. We use JPhyloRef (https://github.com/phyloref/jphyloref) to wrap [Elk](https://liveontologies.github.io/elk-reasoner/).
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, Codex, etc.) when 
 
 ## Overview
 
-The Clade Ontology is an ontology of exemplar phyloreferences curated from PhyloRegnum (https://www.phyloregnum.org/) and peer-reviewed publications. It stores phyloreferences (computable clade definitions) as PHYX files that are converted to n-triples and OWL/JSON-LD for reasoning with an OWL reasoner. We use JPhyloRef (https://github.com/phyloref/jphyloref) to wrap [Elk](https://liveontologies.github.io/elk-reasoner/).
+The Clade Ontology is an ontology of exemplar phyloreferences curated from PhyloRegnum (https://www.phyloregnum.org/) and peer-reviewed publications. It stores phyloreferences (computable clade definitions) in the Phyx format (https://github.com/phyloref/phyx.js/, https://www.phyloref.org/phyx.js/, https://doi.org/10.7717/peerj.12618 -- JSON Schema and JSON-LD contexts available at https://www.phyloref.org/phyx.js/context/) that are converted to n-triples and OWL/JSON-LD for reasoning with an OWL reasoner. We use JPhyloRef (https://github.com/phyloref/jphyloref) to wrap [Elk](https://liveontologies.github.io/elk-reasoner/).
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents (Claude Code, Codex, etc.) when working with code in this repository.
 
 ## Overview
 
@@ -57,6 +57,7 @@ PhyloRegnum DB dump (JSON)
 
 ### Key Directories
 
+- **`data/`** — Git-ignored directory for raw PhyloRegnum database dumps (JSON files) used as input to `regnum2phyx.js`. Not committed.
 - **`phyx/`** — Curated PHYX files organized by source:
   - `from_papers/` — Phyloreferences from peer-reviewed papers (e.g., `Brochu 2003/`)
   - `phylonym/` — Files from the PhyloNym database
@@ -71,8 +72,8 @@ PhyloRegnum DB dump (JSON)
 ### PHYX Format
 
 PHYX files are JSON with:
-- `@context`: points to `http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json`
-- `phylorefs`: array of phyloreference objects with `internalSpecifiers`, `externalSpecifiers`, `cladeDefinition`, etc.
+- `@context`: points to `http://www.phyloref.org/phyx.js/context/v1.1.0/phyx.json`
+- `phylorefs`: array of phyloreference objects with `internalSpecifiers`, `externalSpecifiers`, `definition`, etc.
 - `phylogenies`: array of phylogeny objects with Newick strings
 
 ### Key Library

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+The Clade Ontology is an ontology of exemplar phyloreferences curated from peer-reviewed publications. It stores phyloreferences (computable clade definitions) as PHYX files that are converted to OWL/JSON-LD for reasoning with an OWL reasoner (JPhyloRef + JFact++).
+
+## Commands
+
+```bash
+npm test           # Lint + run all Mocha tests (requires Node.js)
+npm run lint       # ESLint on test/, phyx2ontology/, and regnum2phyx/
+npm run mocha      # Run tests without linting
+npm run build-ontology  # Convert all phyx/ files into CLADO.json
+```
+
+**Run a single test file:**
+```bash
+npx mocha test/test_phyx.js
+npx mocha test/regnum2phyx/exec.js
+```
+
+**Enable slow tests (requires Java + JPhyloRef):**
+```bash
+RUN_SLOW_TESTS=1 npm test
+# Optional env vars: JVM_ARGS, JPHYLOREF_ARGS, MAX_INTERNAL_SPECIFIERS, MAX_EXTERNAL_SPECIFIERS
+```
+
+**Download test dependencies (JPhyloRef JAR and Phyx JSON schema):**
+```bash
+cd test && bash download.sh
+```
+
+**Build the Clade Ontology:**
+```bash
+node phyx2ontology/phyx2ontology.js phyx/ > CLADO.json
+node phyx2ontology/phyx2ontology.js phyx/ --no-phylogenies > CLADO.json
+```
+
+**Convert a PhyloRegnum database dump to Phyx files:**
+```bash
+node regnum2phyx/regnum2phyx.js dump.json -o output_dir/
+node regnum2phyx/regnum2phyx.js dump.json -o output_dir/ --filenames regnum-id
+```
+
+## Architecture
+
+### Data Pipeline
+
+```
+PhyloRegnum DB dump (JSON)
+    → regnum2phyx.js → PHYX files (.json in phyx/)
+    → phyx2ontology.js → CLADO.json (OWL/JSON-LD)
+    → JPhyloRef (Java) → reasoning/test results
+```
+
+### Key Directories
+
+- **`phyx/`** — Curated PHYX files organized by source:
+  - `from_papers/` — Phyloreferences from peer-reviewed papers (e.g., `Brochu 2003/`)
+  - `phylonym/` — Files from the PhyloNym database
+  - `encrypted/` — Git-crypt encrypted files (skipped during processing)
+- **`phyx2ontology/phyx2ontology.js`** — Converts PHYX files to a single Clade Ontology JSON-LD. Reads PHYX files, wraps them via `@phyloref/phyx`, and emits JSON-LD to STDOUT.
+- **`regnum2phyx/regnum2phyx.js`** — Converts PhyloRegnum database dumps (JSON arrays) into individual PHYX files. Handles specifiers, citations (BibJSON format), and author formatting.
+- **`test/`** — Mocha test suite:
+  - `test_phyx.js` — Validates all PHYX files in `phyx/` (JSON schema + JSON-LD conversion). Skips git-crypt encrypted files.
+  - `test_phyx2ontology.js` — Smoke-tests `phyx2ontology.js` execution on all Phyx files.
+  - `regnum2phyx/exec.js` — Tests `regnum2phyx.js` against example dumps in `test/regnum2phyx/examples/` and compares output against `test/regnum2phyx/expected/`.
+
+### PHYX Format
+
+PHYX files are JSON with:
+- `@context`: points to `http://www.phyloref.org/phyx.js/context/v0.2.0/phyx.json`
+- `phylorefs`: array of phyloreference objects with `internalSpecifiers`, `externalSpecifiers`, `cladeDefinition`, etc.
+- `phylogenies`: array of phylogeny objects with Newick strings
+
+### Key Library
+
+`@phyloref/phyx` (npm) provides `PhylorefWrapper`, `PhylogenyWrapper`, and `PhyxWrapper` classes that convert PHYX objects to JSON-LD/OWL class restrictions.
+
+### Linting
+
+ESLint uses `airbnb-base` + `mocha` plugin. Trailing commas required on multiline arrays/objects (not functions). ES6 syntax.
+
+### Git-Crypt
+
+Some PHYX files in `phyx/encrypted/` are git-crypt encrypted. Both `phyx2ontology.js` and `test_phyx.js` detect these by checking for the `\x00GITCRYPT` magic bytes and skip them gracefully.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Clade Ontology is an ontology of exemplar phyloreferences curated from peer-reviewed publications. Phyloreferences in this ontology include their verbatim clade definition and the phylogeny upon which they were initially defined. The ontology therefore acts as both a catalogue of computable clade definitions as well as a test suite of phyloreferences that can be tested to determine if each phyloreference resolves as expected. This ontology is expressed in the [Web Ontology Language (OWL)]. The executable software code in this repository is available for reuse under the terms of the [MIT license].
 
-[![Build Status](https://travis-ci.org/phyloref/clade-ontology.svg?branch=master)](https://travis-ci.org/phyloref/clade-ontology)
+[![Test](https://github.com/phyloref/clade-ontology/actions/workflows/test.yaml/badge.svg)](https://github.com/phyloref/clade-ontology/actions/workflows/test.yaml)
 
 ## Executing phyloreferences as a test suite
 
@@ -11,7 +11,7 @@ To test all phyloreferences, you will need [Node.js] and [Java] installed. You c
  * `JVM_ARGS` contains arguments that are passed to the Java Virtual Machine (i.e. `java $JVM_ARGS -jar ...`). You can use this to set available memory (e.g. `-Xmx12G`) or a directory containing native libraries (e.g. `-Djava.library.path=jphyloref/lib/`).
  * `JPHYLOREF_ARGS` contains arguments that are passed to JPhyloRef (i.e. `java -jar jphyloref.jar test file.owl $JPHYLOREF_ARGS`). You can use this to set the reasoner (e.g. `--reasoner fact++`).
 
-Once pytest and all other required libraries are installed, you can execute all tests by running `npm test` in the root directory of this project.
+Once npm dependencies are installed (`npm install`), you can execute all tests by running `npm test` in the root directory of this project.
 
 ## Data workflow
 
@@ -19,7 +19,7 @@ Curated phyloreferences produced by [Klados] (a phyloreference authoring tool) a
 
 1. Phyx files are converted to JSON-LD files using the [`phyx.js`] library. This tool translates phylogenies stored in [the Newick format] into a series of statements describing individual nodes and their relationships, and translates phyloreferences into OWL class restrictions that describes the nodes they resolve to.
 2. You may need to convert the produced JSON-LD files into RDF/XML using any standards-compliant converter, such as [`rdfpipe`], a part of the [`rdflib`] library.
-3. Any compliant [OWL 2 DL reasoner] should be able to reason over this OWL file, whether represented in JSON-LD or RDF/XML. Phyloreference classes will include all the nodes that they resolve to. In the test suite for the Clade Ontology, we use [`jphyloref`], a Java application that uses the [JFact++ OWL reasoner] to reason over input OWL or JSON-LD files. `jphyloref` can also read the annotations that indicate where each phyloreference was expected to resolve on any of the included phylogenies, and test whether phyloreferences resolved to the expected nodes.
+3. Any compliant [OWL 2 DL reasoner] should be able to reason over this OWL file, whether represented in JSON-LD or RDF/XML. Phyloreference classes will include all the nodes that they resolve to. In the test suite for the Clade Ontology, we use [`jphyloref`], a Java application that uses the [Elk OWL reasoner] to reason over input OWL or JSON-LD files. `jphyloref` can also read the annotations that indicate where each phyloreference was expected to resolve on any of the included phylogenies, and test whether phyloreferences resolved to the expected nodes.
 
 We are currently working on a complete workflow that would allow us to [merge separate Phyx files into a single Clade Ontology] available as a single OWL file available for individual download.
 
@@ -41,6 +41,6 @@ We initially developed the Clade Ontology in Python before replacing it with a N
 [`rdflib`]: http://rdflib.readthedocs.io/
 [OWL 2 DL reasoner]: https://www.w3.org/TR/2012/REC-owl2-direct-semantics-20121211/
 [`jphyloref`]: https://github.com/phyloref/jphyloref
-[JFact++ 1.2.4 OWL reasoner]: http://jfact.sourceforge.net/
-[merge separate Phyx files into a single Clade Ontology]: https://github.com/phyloref/clade-ontology/projects/3
+[Elk OWL reasoner]: https://liveontologies.github.io/elk-reasoner/
+[merge separate PHYX files into a single Clade Ontology]: https://github.com/phyloref/clade-ontology/projects/3
 [v0.1]: https://github.com/phyloref/clade-ontology/releases/tag/v0.1


### PR DESCRIPTION
This PR carries only the **documentation & repo-meta** changes — no code or test behaviour:

- README fixes (incl. TravisCI → GitHub Actions badge) and minor wording.
- `.gitignore` the `/data/` directory used for raw PhyloRegnum dumps and other intermediate files.
- Add `AGENTS.md` (guidance for AI coding agents) and `CLAUDE.md` as a symlink to it.

Part of the **split of #108** ("Get tests working again") into smaller, reviewable PRs. Does not depend on any other PRs.