### PR TITLE
phyx2ontology test fixes

### DIFF
--- a/phyx2ontology/phyx2ontology.js
+++ b/phyx2ontology/phyx2ontology.js
@@ -53,7 +53,7 @@ function findPHYXFiles(dirPath) {
 }
 
 // Read command-line arguments.
-const argv = yargs.usage('Usage: $0 <directories or files to convert> [--no-phylogenies]')
+const argv = yargs(process.argv.slice(2)).usage('Usage: $0 <directories or files to convert> [--no-phylogenies]')
   .demandCommand(1) // Make sure there's at least one directory or file!
   .option('no-phylogenies', {
     // --no-phylogenies: Flag for turning off including phylogenies in the produced ontology.
@@ -128,6 +128,10 @@ for (const phyxFile of jsons) {
       console.warn(`Phyloreference ${phylorefWrapper.label} has `
         + `${phylorefWrapper.externalSpecifiers.length} external specifiers but `
         + `the limit is ${MAX_EXTERNAL_SPECIFIERS}`);
+      continue;
+    }
+    if (phylorefWrapper.internalSpecifiers.length === 1 && phylorefWrapper.externalSpecifiers.length === 0) {
+      console.warn(`Phyloreference ${phylorefWrapper.label} has only 1 internal specifier and no external specifiers — skipping (single-specifier limitation)`);
       continue;
     }
 

--- a/test/test_phyx2ontology.js
+++ b/test/test_phyx2ontology.js
@@ -20,11 +20,11 @@ describe('Executing phyx2ontology.js on all current Phyx files', function () {
   this.timeout(10000);
 
   const child = ChildProcess.spawnSync(process.execPath, [
-    'phyx2ontology/phyx2ontology.js', BASE_DIR, '>', tmpfilename,
+    'phyx2ontology/phyx2ontology.js', BASE_DIR,
   ], {
     encoding: 'utf8',
-    shell: true,
   });
+  if (child.stdout) fs.writeFileSync(tmpfilename, child.stdout, { encoding: 'utf8' });
 
   it('should execute successfully', () => {
     assert.isNull(child.signal, `Terminated because of signal ${child.signal}`);

--- a/test/test_phyx2ontology.js
+++ b/test/test_phyx2ontology.js
@@ -17,14 +17,19 @@ const assert = chai.assert;
 const tmpfilename = tmp.fileSync().name;
 
 describe('Executing phyx2ontology.js on all current Phyx files', function () {
-  this.timeout(10000);
+  this.timeout(60000);
 
+  // Redirect the child's stdout straight to a file via stdio. spawnSync's default
+  // maxBuffer is 1 MB and the ontology output for the current phyx/ corpus is
+  // hundreds of MB; using an in-memory buffer would cause Node to kill the child
+  // with SIGTERM as soon as that limit is exceeded.
+  const outFd = fs.openSync(tmpfilename, 'w');
   const child = ChildProcess.spawnSync(process.execPath, [
     'phyx2ontology/phyx2ontology.js', BASE_DIR,
   ], {
-    encoding: 'utf8',
+    stdio: ['ignore', outFd, 'inherit'],
   });
-  if (child.stdout) fs.writeFileSync(tmpfilename, child.stdout, { encoding: 'utf8' });
+  fs.closeSync(outFd);
 
   it('should execute successfully', () => {
     assert.isNull(child.signal, `Terminated because of signal ${child.signal}`);


### PR DESCRIPTION
Fixes **`phyx2ontology/phyx2ontology.js`** and its smoke test **`test/test_phyx2ontology.js`**:
- Update yargs syntax and guard phylorefs that have only a single internal specifier.
- Remove `shell: true` from `spawnSync`; stream stdout to a file and raise the timeout so large conversions don't hang the test.

⚠️ CI will fail until all three PRs are merged. Should be merged after PR #117.

Part of the **split of #108** ("Get tests working again"). Targets `split/deps` (the upgrade base).